### PR TITLE
ENH: Change order of tools on toolbar

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -46,6 +46,7 @@
                 name="Save session"
                 @click="saveDialog = true"
               />
+              <div class="my-1 tool-separator" />
               <v-menu offset-x>
                 <template v-slot:activator="{ on, attrs }">
                   <div>
@@ -445,6 +446,13 @@ export default defineComponent({
 
 .toolbar-button {
   min-height: 100%; /* fill toolbar height */
+}
+
+.tool-separator {
+  width: 75%;
+  height: 1px;
+  border: none;
+  border-top: 1px solid rgb(112, 112, 112);
 }
 
 .vertical-offset-margin {

--- a/src/components/ToolStrip.vue
+++ b/src/components/ToolStrip.vue
@@ -39,6 +39,19 @@
         @click="toggle"
       />
     </groupable-item>
+    <groupable-item
+      v-slot:default="{ active, toggle }"
+      :value="Tools.Crosshairs"
+    >
+      <tool-button
+        size="40"
+        icon="mdi-crosshairs"
+        name="Crosshairs"
+        :buttonClass="['tool-btn', active ? 'tool-btn-selected' : '']"
+        :disabled="noCurrentImage"
+        @click="toggle"
+      />
+    </groupable-item>
     <div class="my-1 tool-separator" />
     <groupable-item v-slot:default="{ active, toggle }" :value="Tools.Paint">
       <v-menu
@@ -68,6 +81,17 @@
         <paint-controls />
       </v-menu>
     </groupable-item>
+    <groupable-item v-slot:default="{ active, toggle }" :value="Tools.Ruler">
+      <tool-button
+        size="40"
+        icon="mdi-ruler"
+        name="Ruler"
+        :buttonClass="['tool-btn', active ? 'tool-btn-selected' : '']"
+        :disabled="noCurrentImage"
+        @click="toggle"
+      />
+    </groupable-item>
+    <div class="my-1 tool-separator" />
     <groupable-item v-slot:default="{ active, toggle }" :value="Tools.Crop">
       <v-menu v-model="cropMenu" offset-x open-on-hover close-on-content-click>
         <template v-slot:activator="{ attrs, on }">
@@ -90,29 +114,6 @@
         </template>
         <crop-controls />
       </v-menu>
-    </groupable-item>
-    <groupable-item v-slot:default="{ active, toggle }" :value="Tools.Ruler">
-      <tool-button
-        size="40"
-        icon="mdi-ruler"
-        name="Ruler"
-        :buttonClass="['tool-btn', active ? 'tool-btn-selected' : '']"
-        :disabled="noCurrentImage"
-        @click="toggle"
-      />
-    </groupable-item>
-    <groupable-item
-      v-slot:default="{ active, toggle }"
-      :value="Tools.Crosshairs"
-    >
-      <tool-button
-        size="40"
-        icon="mdi-crosshairs"
-        name="Crosshairs"
-        :buttonClass="['tool-btn', active ? 'tool-btn-selected' : '']"
-        :disabled="noCurrentImage"
-        @click="toggle"
-      />
     </groupable-item>
   </item-group>
 </template>


### PR DESCRIPTION
Group 2D controls (w/L, pan, zoom, crosshairs), annotation tools (paint, ruler), and 3D controls (cropping).   Add divider between each group.

New layout:

| Before | After |
|--|--|
| ![image](https://user-images.githubusercontent.com/219043/202930655-72694acc-4ccf-4709-9c3f-72466e5007b6.png) | ![image](https://user-images.githubusercontent.com/279727/202929980-caf2641e-4f3d-4663-b81a-f411cc08ac78.png) |





