### PR TITLE
chore(docs): use action for Pages publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,28 +3,50 @@ on:
   push:
     branches:
       - main
+  # enable manual trigger
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
 
 jobs:
-  publish:
-    name: Publish
+  build:
+    name: Build Docs
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
       - name: Setup node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16
       - name: Install dependencies
         run: npm ci
+      - name: Build docs
+        run: npm run doc
+      - name: Upload pages artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: './documentation/build-tmp/public'
 
-      - name: Set git config
-        run: |
-          git config --global user.name "Github Actions"
-          git config --global user.email "forrest.li@kitware.com"
-
-      - name: Publish website
-        env:
-          GIT_PUBLISH_URL: https://${{ secrets.GH_PUBLISH_CREDS }}@github.com/Kitware/VolView.git
-        run: npm run doc:publish
+  deploy:
+    name: Deploy Docs
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1


### PR DESCRIPTION
Instead of using `kw-doc` to publish, we use Pages artifacts to achieve the same without pushing to the repo.