### PR TITLE
fix(DragAndDrop): conflict with native drop event

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <drag-and-drop enabled @drop="openFiles" id="app-container">
+  <drag-and-drop enabled @drop-files="openFiles" id="app-container">
     <template v-slot="{ dragHover }">
       <v-app>
         <v-app-bar app dense clipped-left>

--- a/src/components/DragAndDrop.vue
+++ b/src/components/DragAndDrop.vue
@@ -92,9 +92,9 @@ export default {
             return getAsEntry.call(item);
           });
           const files = await readAllFiles(entries);
-          this.$emit('drop', files);
+          this.$emit('drop-files', files);
         } else {
-          this.$emit('drop', Array.from(ev.dataTransfer.files));
+          this.$emit('drop-files', Array.from(ev.dataTransfer.files));
         }
       }
     },


### PR DESCRIPTION
Do not overload the native "drop" event, otherwise it'll trigger twice.