### PR TITLE
Fixes a stack memory leak and extraneous readDICOMTag XHRs

### DIFF
--- a/patches/@kitware+vtk.js+26.5.4.patch
+++ b/patches/@kitware+vtk.js+26.5.4.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/@kitware/vtk.js/Rendering/OpenGL/Texture.js b/node_modules/@kitware/vtk.js/Rendering/OpenGL/Texture.js
+index e2e24b5..35efba5 100644
+--- a/node_modules/@kitware/vtk.js/Rendering/OpenGL/Texture.js
++++ b/node_modules/@kitware/vtk.js/Rendering/OpenGL/Texture.js
+@@ -7,6 +7,8 @@ import { Q as isPowerOfTwo, M as nearestPowerOfTwo } from '../../Common/Core/Mat
+ import vtkViewNode from '../SceneGraph/ViewNode.js';
+ import { registerOverride } from './ViewNodeFactory.js';
+ 
++var toHalf = HalfFloat.toHalf;
++
+ function ownKeys(object, enumerableOnly) { var keys = Object.keys(object); if (Object.getOwnPropertySymbols) { var symbols = Object.getOwnPropertySymbols(object); enumerableOnly && (symbols = symbols.filter(function (sym) { return Object.getOwnPropertyDescriptor(object, sym).enumerable; })), keys.push.apply(keys, symbols); } return keys; }
+ 
+ function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = null != arguments[i] ? arguments[i] : {}; i % 2 ? ownKeys(Object(source), !0).forEach(function (key) { _defineProperty(target, key, source[key]); }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(target, Object.getOwnPropertyDescriptors(source)) : ownKeys(Object(source)).forEach(function (key) { Object.defineProperty(target, key, Object.getOwnPropertyDescriptor(source, key)); }); } return target; }
+@@ -609,9 +611,10 @@ function vtkOpenGLTexture(publicAPI, model) {
+       for (var _idx2 = 0; _idx2 < data.length; _idx2++) {
+         if (data[_idx2]) {
+           var newArray = new Uint16Array(pixCount);
++          var src = data[_idx2];
+ 
+           for (var i = 0; i < pixCount; i++) {
+-            newArray[i] = HalfFloat.toHalf(data[_idx2][i]);
++            newArray[i] = toHalf(src[i]);
+           }
+ 
+           pixData.push(newArray);

--- a/patches/itk-wasm+1.0.0-b.66.patch
+++ b/patches/itk-wasm+1.0.0-b.66.patch
@@ -1,0 +1,21 @@
+diff --git a/node_modules/itk-wasm/dist/web-workers/bundles/pipeline.worker.js b/node_modules/itk-wasm/dist/web-workers/bundles/pipeline.worker.js
+index 8f3ea5f..67a775f 100644
+--- a/node_modules/itk-wasm/dist/web-workers/bundles/pipeline.worker.js
++++ b/node_modules/itk-wasm/dist/web-workers/bundles/pipeline.worker.js
+@@ -2570,6 +2570,7 @@
+       pipelineModule.resetModuleStdout();
+       pipelineModule.resetModuleStderr();
+       let returnValue = 0;
++      const stackPtr = pipelineModule.stackSave();
+       try {
+           returnValue = pipelineModule.callMain(args.slice());
+       }
+@@ -2588,6 +2589,8 @@
+               }
+           }
+           throw exception;
++      } finally {
++        pipelineModule.stackRestore(stackPtr);
+       }
+       const stdout = pipelineModule.getModuleStdout();
+       const stderr = pipelineModule.getModuleStderr();

--- a/src/io/dicom.ts
+++ b/src/io/dicom.ts
@@ -45,10 +45,18 @@ export class DICOMIO {
           .then((result) => {
             if (result.webWorker) {
               this.webWorker = result.webWorker;
-              resolve();
             } else {
               reject(new Error('Could not initialize webworker'));
             }
+          })
+          .then(async () => {
+            // preload read-dicom-tags pipeline
+            try {
+              await readDICOMTags(this.webWorker, new File([], ''), null);
+            } catch {
+              // ignore
+            }
+            resolve();
           })
           .catch(reject);
       });

--- a/src/io/itk/itkConfig.js
+++ b/src/io/itk/itkConfig.js
@@ -1,6 +1,6 @@
 const base = process.env.VUE_APP_PUBLIC_PATH ?? '';
 const itkConfig = {
-  pipelineWorkerUrl: `${base}/itk/web-workers/min-bundles/pipeline.worker.js`,
+  pipelineWorkerUrl: `${base}/itk/pipeline.worker.js`,
   imageIOUrl: `${base}/itk/image-io`,
   meshIOUrl: `${base}/itk/mesh-io`,
   pipelinesUrl: `${base}/itk/pipelines`,

--- a/vue.config.js
+++ b/vue.config.js
@@ -62,9 +62,11 @@ module.exports = {
               'node_modules',
               'itk-wasm',
               'dist',
-              'web-workers'
+              'web-workers',
+              'bundles',
+              'pipeline.worker.js'
             ),
-            to: path.join(__dirname, 'dist', 'itk', 'web-workers'),
+            to: path.join(__dirname, 'dist', 'itk'),
           },
           {
             from: path.join(__dirname, 'node_modules', 'itk-image-io'),
@@ -76,7 +78,13 @@ module.exports = {
             },
           },
           {
-            from: path.join(__dirname, 'src', 'io', 'itk-dicom', 'emscripten-build'),
+            from: path.join(
+              __dirname,
+              'src',
+              'io',
+              'itk-dicom',
+              'emscripten-build'
+            ),
             to: path.join(__dirname, 'dist', 'itk', 'pipelines', '[name][ext]'),
             filter: (resourcePath) => {
               return path.basename(resourcePath).startsWith('dicom');


### PR DESCRIPTION
- Testing minor optimizations to a hot loop in vtkOpenGLTexture by reducing the number of object lookups.
- Preloads the `read-dicom-tags` pipeline to avoid multiple fetch calls for the same pipeline when reading in a loop. This is less of a concern for image file readers, but it's still good to note it as a potential issue.
- Restores the stack pointer after every `main()` call, since we do not re-initialize the webworker/emscripten program on every call. Cleans up a stack memory leak. (This makes no assumption on the state of the heap in between main() runs.)

FYI @thewtex @PaulHax the last point above may be a point of discussion for re-using webworkers. Do we continue to treat main() as the entrypoint, or do we instead expose some separate run() function?