### PR TITLE
fix(vue.config): default public path

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -31,7 +31,7 @@ module.exports = {
       return args;
     });
   },
-  publicPath: process.env.VUE_APP_PUBLIC_PATH || '',
+  publicPath: process.env.VUE_APP_PUBLIC_PATH || '/',
   configureWebpack: {
     devtool: 'source-map',
     resolve: {


### PR DESCRIPTION
Fixes #286. The default public path should be `/`.