### PR TITLE
Remote state

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -296,7 +296,7 @@ async function loadRemoteFilesFromURLParams(
   setError: (err: Error) => void
 ) {
   const urls = wrapInArray(params.urls);
-  const names = wrapInArray(params.names);
+  const names = wrapInArray(params.names ?? []); // optional names should resolve to [] if params.names === undefined
   const fetchParams = urls.map((url, idx) => ({
     url,
     remoteFilename:

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -314,7 +314,7 @@ async function loadRemoteFilesFromURLParams(
     ...fetchParams[idx],
   }));
 
-  const [fulfilled, rejected] = partition(
+  const [downloaded, rejected] = partition(
     ({ result }) => isFulfilled(result) && result.value.size !== 0,
     withParams
   );
@@ -327,7 +327,7 @@ async function loadRemoteFilesFromURLParams(
     );
   }
 
-  const datasetFiles = fulfilled.map(({ result, url }) =>
+  const datasetFiles = downloaded.map(({ result, url }) =>
     makeRemote(url, (result as PromiseFulfilledResult<File>).value)
   );
 

--- a/src/components/SampleDataBrowser.vue
+++ b/src/components/SampleDataBrowser.vue
@@ -96,7 +96,7 @@ export default defineComponent({
 
         if (sampleFile) {
           const [loadResult] = await datasetStore.loadFiles([
-            makeRemote(sample.url)(sampleFile),
+            makeRemote(sample.url, sampleFile),
           ]);
           if (loadResult?.loaded) {
             const selection = convertSuccessResultToDataSelection(loadResult);

--- a/src/components/SampleDataBrowser.vue
+++ b/src/components/SampleDataBrowser.vue
@@ -17,6 +17,7 @@ import { SampleDataset } from '../types';
 import { useImageStore } from '../store/datasets-images';
 import { useDICOMStore } from '../store/datasets-dicom';
 import { fetchFile } from '../utils/fetch';
+import { makeRemote } from '../store/datasets-files';
 
 enum ProgressState {
   Pending,
@@ -94,7 +95,9 @@ export default defineComponent({
         status.progress[sample.name].state = ProgressState.Done;
 
         if (sampleFile) {
-          const [loadResult] = await datasetStore.loadFiles([sampleFile]);
+          const [loadResult] = await datasetStore.loadFiles([
+            makeRemote(sample.url)(sampleFile),
+          ]);
           if (loadResult?.loaded) {
             const selection = convertSuccessResultToDataSelection(loadResult);
             if (selection) {

--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -70,6 +70,8 @@ async function getFileTypeFromMagic(file: File): Promise<string | null> {
  * @param file
  */
 export async function retypeFile(file: File): Promise<File> {
+  if (file.type) return file;
+
   let type: string | null;
 
   type =

--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -1,6 +1,5 @@
 import { extensionToImageIO } from 'itk-wasm';
 import { extractFilesFromZip } from './zip';
-import { FileEntry } from './types';
 import { DatasetFile } from '../store/datasets-files';
 
 export const ARCHIVE_FILE_TYPES = new Set(['zip', 'application/zip']);
@@ -98,7 +97,7 @@ export async function extractArchivesRecursively(
     files.map(async (file) => {
       if (ARCHIVE_FILE_TYPES.has(file.file.type)) {
         const entries = await extractFilesFromZip(file.file);
-        return entries.map((withPath) => ({ ...file, ...withPath })); // preserve DatasetFile url provenance
+        return entries.map((withPath) => ({ ...file, ...withPath })); // preserve DatasetFile remote provenance
       }
 
       return [file];

--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -1,6 +1,7 @@
 import { extensionToImageIO } from 'itk-wasm';
 import { extractFilesFromZip } from './zip';
 import { FileEntry } from './types';
+import { DatasetFile } from '../store/datasets-files';
 
 export const ARCHIVE_FILE_TYPES = new Set(['zip', 'application/zip']);
 
@@ -91,27 +92,28 @@ export async function retypeFile(file: File): Promise<File> {
 }
 
 export async function extractArchivesRecursively(
-  files: File[]
-): Promise<FileEntry[]> {
+  files: DatasetFile[]
+): Promise<DatasetFile[]> {
   const results = await Promise.all(
     files.map(async (file) => {
-      if (ARCHIVE_FILE_TYPES.has(file.type)) {
-        return extractFilesFromZip(file);
+      if (ARCHIVE_FILE_TYPES.has(file.file.type)) {
+        const entries = await extractFilesFromZip(file.file);
+        return entries.map((withPath) => ({ ...file, ...withPath })); // preserve DatasetFile url provenance
       }
 
-      return [{ file, path: '' }];
+      return [file];
     })
   );
 
   const archivedEntries = await Promise.all(
     results.flat().map(async (entry) => {
-      return { file: await retypeFile(entry.file), path: entry.path };
+      return { ...entry, file: await retypeFile(entry.file) };
     })
   );
 
-  const archives = archivedEntries
-    .filter(({ file }) => ARCHIVE_FILE_TYPES.has(file.type))
-    .map(({ file }) => file);
+  const archives = archivedEntries.filter(({ file }) =>
+    ARCHIVE_FILE_TYPES.has(file.type)
+  );
 
   if (archives.length > 0) {
     const moreEntries = await extractArchivesRecursively(archives);

--- a/src/io/manifest.ts
+++ b/src/io/manifest.ts
@@ -17,7 +17,8 @@ async function fetchRemoteManifest(
 ) {
   return Promise.all(
     manifest.resources.map(async (resource) =>
-      makeRemote(resource.url)(
+      makeRemote(
+        resource.url,
         await fetchFile(
           resource.url,
           resource.name ?? getURLBasename(resource.url)

--- a/src/io/manifest.ts
+++ b/src/io/manifest.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { DatasetFile, makeRemote } from '../store/datasets-files';
+import { makeRemote } from '../store/datasets-files';
 import { getURLBasename } from '../utils';
 import { fetchFile } from '../utils/fetch';
 
@@ -28,9 +28,9 @@ async function fetchRemoteManifest(
   );
 }
 
-export async function readRemoteManifestFile(manifestFile: DatasetFile) {
+export async function readRemoteManifestFile(manifestFile: File) {
   const decoder = new TextDecoder();
-  const ab = await manifestFile.file.arrayBuffer();
+  const ab = await manifestFile.arrayBuffer();
   const text = decoder.decode(new Uint8Array(ab));
   const manifest = RemoteDataManifest.parse(JSON.parse(text));
   return fetchRemoteManifest(manifest);

--- a/src/io/manifest.ts
+++ b/src/io/manifest.ts
@@ -22,6 +22,7 @@ async function fetchRemoteManifest(
 }
 
 export async function readRemoteManifestFile(manifestFile: File) {
+  // TODO store Files and URLs so FileStore can replace file in SerializeData
   const decoder = new TextDecoder();
   const ab = await manifestFile.arrayBuffer();
   const text = decoder.decode(new Uint8Array(ab));

--- a/src/io/state-file/index.ts
+++ b/src/io/state-file/index.ts
@@ -26,7 +26,7 @@ import { Manifest, ManifestSchema } from './schema';
 import { deserializeDatasetFiles } from './utils';
 
 const MANIFEST = 'manifest.json';
-const VERSION = '0.0.2';
+const VERSION = '0.0.3';
 
 export async function save(fileName: string) {
   const datasetStore = useDatasetStore();
@@ -39,7 +39,7 @@ export async function save(fileName: string) {
   const manifest: Manifest = {
     version: VERSION,
     datasets: [],
-    remoteDatasetFileEntries: {},
+    remoteFiles: {},
     labelMaps: [],
     tools: {
       rulers: [],

--- a/src/io/state-file/index.ts
+++ b/src/io/state-file/index.ts
@@ -15,7 +15,7 @@ import {
 } from '../../store/datasets';
 import { useDICOMStore } from '../../store/datasets-dicom';
 import { useLayersStore } from '../../store/datasets-layers';
-import { makeZip, ZipDatasetFile } from '../../store/datasets-files';
+import { makeLocal, ZipDatasetFile } from '../../store/datasets-files';
 import {
   ARCHIVE_FILE_TYPES,
   extractArchivesRecursively,
@@ -164,7 +164,7 @@ async function restore(state: FileEntry[]): Promise<LoadResult[]> {
 export async function loadState(stateFile: File) {
   const typedFile = await retypeFile(stateFile);
   const fileEntries = (await extractArchivesRecursively([
-    makeZip()(typedFile),
+    makeLocal(typedFile),
   ])) as Array<ZipDatasetFile>;
 
   return restore(fileEntries);

--- a/src/io/state-file/index.ts
+++ b/src/io/state-file/index.ts
@@ -1,6 +1,5 @@
 import JSZip from 'jszip';
 import { saveAs } from 'file-saver';
-import { useFileStore } from '@/src/store/datasets-files';
 import { LayoutDirection } from '@/src/types/layout';
 import { useViewStore } from '@/src/store/views';
 import { useLabelmapStore } from '@/src/store/datasets-labelmaps';
@@ -82,7 +81,6 @@ export async function save(fileName: string) {
 async function restore(state: FileEntry[]): Promise<LoadResult[]> {
   const datasetStore = useDatasetStore();
   const dicomStore = useDICOMStore();
-  const fileStore = useFileStore();
   const viewStore = useViewStore();
   const labelStore = useLabelmapStore();
   const toolStore = useToolStore();
@@ -120,7 +118,6 @@ async function restore(state: FileEntry[]): Promise<LoadResult[]> {
       .then((result) => {
         if (result.loaded) {
           stateIDToStoreID[dataset.id] = result.dataID;
-          fileStore.add(result.dataID, files); // not done by imageStore, unlike dicomStore
         }
 
         return result;
@@ -171,8 +168,9 @@ export async function loadState(stateFile: File) {
 }
 
 export async function isStateFile(file: File) {
-  if (ARCHIVE_FILE_TYPES.has(file.type)) {
-    const zip = await JSZip.loadAsync(file);
+  const typedFile = await retypeFile(file);
+  if (ARCHIVE_FILE_TYPES.has(typedFile.type)) {
+    const zip = await JSZip.loadAsync(typedFile);
 
     return zip.file(MANIFEST) !== null;
   }

--- a/src/io/state-file/index.ts
+++ b/src/io/state-file/index.ts
@@ -15,6 +15,7 @@ import {
 } from '../../store/datasets';
 import { useDICOMStore } from '../../store/datasets-dicom';
 import { useLayersStore } from '../../store/datasets-layers';
+import { makeZip, ZipDatasetFile } from '../../store/datasets-files';
 import {
   ARCHIVE_FILE_TYPES,
   extractArchivesRecursively,
@@ -38,7 +39,7 @@ export async function save(fileName: string) {
   const manifest: Manifest = {
     version: VERSION,
     datasets: [],
-    remoteDatasetFiles: {},
+    remoteDatasetFileEntries: {},
     labelMaps: [],
     tools: {
       rulers: [],
@@ -162,7 +163,9 @@ async function restore(state: FileEntry[]): Promise<LoadResult[]> {
 
 export async function loadState(stateFile: File) {
   const typedFile = await retypeFile(stateFile);
-  const fileEntries = await extractArchivesRecursively([typedFile]);
+  const fileEntries = (await extractArchivesRecursively([
+    makeZip()(typedFile),
+  ])) as Array<ZipDatasetFile>;
 
   return restore(fileEntries);
 }

--- a/src/io/state-file/index.ts
+++ b/src/io/state-file/index.ts
@@ -106,12 +106,12 @@ async function restore(state: FileEntry[]): Promise<LoadResult[]> {
 
   const statuses: LoadResult[] = [];
 
-  const deserializeFiles = deserializeDatasetFiles(manifest, state);
+  const deserializeDataset = deserializeDatasetFiles(manifest, state);
   // We load them sequentially to preserve the order
   // eslint-disable-next-line no-restricted-syntax
   for (const dataset of datasets) {
     // eslint-disable-next-line no-await-in-loop
-    const files = await deserializeFiles(dataset);
+    const files = await deserializeDataset(dataset);
 
     // eslint-disable-next-line no-await-in-loop
     const status = await datasetStore

--- a/src/io/state-file/index.ts
+++ b/src/io/state-file/index.ts
@@ -23,7 +23,7 @@ import {
 } from '../io';
 import { FileEntry } from '../types';
 import { Manifest, ManifestSchema } from './schema';
-import { deserializeFiles, RemoteFileCache } from './utils';
+import { makeDeserializeFiles } from './utils';
 
 const MANIFEST = 'manifest.json';
 const VERSION = '0.0.2';
@@ -106,12 +106,12 @@ async function restore(state: FileEntry[]): Promise<LoadResult[]> {
 
   const statuses: LoadResult[] = [];
 
-  const remoteFileCache: RemoteFileCache = {};
+  const deserializeFiles = makeDeserializeFiles(state);
   // We load them sequentially to preserve the order
   // eslint-disable-next-line no-restricted-syntax
   for (const dataSet of dataSets) {
     // eslint-disable-next-line no-await-in-loop
-    const files = await deserializeFiles(state, remoteFileCache, dataSet.path);
+    const files = await deserializeFiles(dataSet.path);
 
     // eslint-disable-next-line no-await-in-loop
     const status = await datasetStore

--- a/src/io/state-file/schema.ts
+++ b/src/io/state-file/schema.ts
@@ -58,12 +58,12 @@ const Dataset = z.object({
 });
 export type Dataset = z.infer<typeof Dataset>;
 
-const RemoteDatasetFile = z.object({
+const RemoteDatasetFileEntry = z.object({
   path: z.string(),
   url: z.string(),
   name: z.string(),
 });
-export type RemoteDatasetFile = z.infer<typeof RemoteDatasetFile>;
+export type RemoteDatasetFileEntry = z.infer<typeof RemoteDatasetFileEntry>;
 
 const LayoutDirectionNative = z.nativeEnum(LayoutDirection);
 
@@ -292,7 +292,7 @@ export type ParentToLayers = z.infer<typeof ParentToLayers>;
 export const ManifestSchema = z.object({
   version: z.string(),
   datasets: Dataset.array(),
-  remoteDatasetFiles: z.record(RemoteDatasetFile.array()),
+  remoteDatasetFileEntries: z.record(RemoteDatasetFileEntry.array()),
   labelMaps: LabelMap.array(),
   tools: Tools,
   views: View.array(),

--- a/src/io/state-file/schema.ts
+++ b/src/io/state-file/schema.ts
@@ -61,6 +61,7 @@ export type Dataset = z.infer<typeof Dataset>;
 const RemoteDatasetFileEntry = z.object({
   path: z.string(),
   url: z.string(),
+  remoteFilename: z.string(),
   name: z.string(),
 });
 export type RemoteDatasetFileEntry = z.infer<typeof RemoteDatasetFileEntry>;

--- a/src/io/state-file/schema.ts
+++ b/src/io/state-file/schema.ts
@@ -59,7 +59,7 @@ const Dataset = z.object({
 export type Dataset = z.infer<typeof Dataset>;
 
 const RemoteFile = z.object({
-  path: z.string(),
+  archivePath: z.string().optional(),
   url: z.string(),
   remoteFilename: z.string(),
   name: z.string(),

--- a/src/io/state-file/schema.ts
+++ b/src/io/state-file/schema.ts
@@ -35,12 +35,12 @@ import {
   BlendConfig,
 } from '../../types/views';
 
-export enum DataSetType {
+export enum DatasetType {
   DICOM = 'dicom',
   IMAGE = 'image',
 }
 
-const DataSetTypeNative = z.nativeEnum(DataSetType);
+const DatasetTypeNative = z.nativeEnum(DatasetType);
 
 const LPSAxisDir: z.ZodType<LPSAxisDir> = z.union([
   z.literal('Left'),
@@ -51,12 +51,19 @@ const LPSAxisDir: z.ZodType<LPSAxisDir> = z.union([
   z.literal('Inferior'),
 ]);
 
-const DataSet = z.object({
+const Dataset = z.object({
   id: z.string(),
   path: z.string(),
-  type: DataSetTypeNative,
+  type: DatasetTypeNative,
 });
-export type DataSet = z.infer<typeof DataSet>;
+export type Dataset = z.infer<typeof Dataset>;
+
+const RemoteDatasetFile = z.object({
+  path: z.string(),
+  url: z.string(),
+  name: z.string(),
+});
+export type RemoteDatasetFile = z.infer<typeof RemoteDatasetFile>;
 
 const LayoutDirectionNative = z.nativeEnum(LayoutDirection);
 
@@ -284,7 +291,8 @@ export type ParentToLayers = z.infer<typeof ParentToLayers>;
 
 export const ManifestSchema = z.object({
   version: z.string(),
-  dataSets: DataSet.array(),
+  datasets: Dataset.array(),
+  remoteDatasetFiles: z.record(RemoteDatasetFile.array()),
   labelMaps: LabelMap.array(),
   tools: Tools,
   views: View.array(),

--- a/src/io/state-file/schema.ts
+++ b/src/io/state-file/schema.ts
@@ -58,13 +58,13 @@ const Dataset = z.object({
 });
 export type Dataset = z.infer<typeof Dataset>;
 
-const RemoteDatasetFileEntry = z.object({
+const RemoteFile = z.object({
   path: z.string(),
   url: z.string(),
   remoteFilename: z.string(),
   name: z.string(),
 });
-export type RemoteDatasetFileEntry = z.infer<typeof RemoteDatasetFileEntry>;
+export type RemoteFile = z.infer<typeof RemoteFile>;
 
 const LayoutDirectionNative = z.nativeEnum(LayoutDirection);
 
@@ -293,7 +293,7 @@ export type ParentToLayers = z.infer<typeof ParentToLayers>;
 export const ManifestSchema = z.object({
   version: z.string(),
   datasets: Dataset.array(),
-  remoteDatasetFileEntries: z.record(RemoteDatasetFileEntry.array()),
+  remoteFiles: z.record(RemoteFile.array()),
   labelMaps: LabelMap.array(),
   tools: Tools,
   views: View.array(),

--- a/src/io/types.ts
+++ b/src/io/types.ts
@@ -1,4 +1,4 @@
 export interface FileEntry {
   file: File;
-  path: string;
+  archivePath: string;
 }

--- a/src/io/zip.ts
+++ b/src/io/zip.ts
@@ -24,7 +24,7 @@ export async function extractFilesFromZip(zipFile: File): Promise<FileEntry[]> {
     return files.map((file, index) => {
       return {
         file,
-        path: paths[index],
+        archivePath: paths[index],
       };
     });
   });

--- a/src/store/__tests__/datasets.spec.ts
+++ b/src/store/__tests__/datasets.spec.ts
@@ -10,6 +10,7 @@ import { FILE_READERS } from '@/src/io';
 import { CorePiniaProviderPlugin } from '@/src/core/provider';
 import ProxyWrapper from '@/src/core/proxies';
 import Sinon from 'sinon';
+import { makeLocal } from '../datasets-files';
 
 chai.use(chaiSubset);
 
@@ -35,7 +36,7 @@ describe('Dataset store', () => {
       makeEmptyFile('test1.nrrd'),
       makeEmptyFile('test2.nrrd'),
       makeEmptyFile('test3.nrrd'),
-    ];
+    ].map(makeLocal);
 
     // override nrrd reader
     const testImageData = vtkImageData.newInstance();
@@ -51,7 +52,7 @@ describe('Dataset store', () => {
 
   it('handles missing readers', async () => {
     const datasetStore = useDatasetStore();
-    const files = [makeEmptyFile('test1.invalid')];
+    const files = [makeEmptyFile('test1.invalid')].map(makeLocal);
 
     const loadResults = await datasetStore.loadFiles(files);
     expect(loadResults).to.containSubset([
@@ -61,7 +62,7 @@ describe('Dataset store', () => {
 
   it('handles readers that return an error', async () => {
     const datasetStore = useDatasetStore();
-    const files = [makeEmptyFile('test1.invalid')];
+    const files = [makeEmptyFile('test1.invalid')].map(makeLocal);
 
     FILE_READERS.set('invalid', () => {
       throw new Error('invalid!');

--- a/src/store/datasets-files.ts
+++ b/src/store/datasets-files.ts
@@ -1,8 +1,25 @@
 import { del, set } from '@vue/composition-api';
 import { defineStore } from 'pinia';
+import { pluck } from '../utils';
+
+export type DatasetUrl = string & { __type: 'UrlString' };
+export type LocalDatasetFileMeta = { path: string; file: { name: string } };
+export type RemoteDatasetFileMeta = LocalDatasetFileMeta & { url: DatasetUrl };
+export type DatasetFileMeta = LocalDatasetFileMeta | RemoteDatasetFileMeta;
+
+export type DatasetFile = DatasetFileMeta & {
+  file: File;
+};
+
+export function isRemote(
+  datasetFile: DatasetFileMeta
+): datasetFile is RemoteDatasetFileMeta {
+  // return (datasetFile as RemoteDatasetFileMeta).url !== undefined;
+  return 'url' in datasetFile;
+}
 
 interface State {
-  byDataID: Record<string, File[]>;
+  byDataID: Record<string, DatasetFile[]>;
   fileToRemote: Map<File, string>;
 }
 
@@ -14,24 +31,24 @@ export const useFileStore = defineStore('files', {
     byDataID: {},
     fileToRemote: new Map(),
   }),
+
   getters: {
-    getFiles: (state) => {
-      return (dataID: string) => {
-        if (dataID in state.byDataID) {
-          return state.byDataID[dataID];
-        }
-        return null;
-      };
-    },
+    getDatasetFiles: (state) => (dataID: string) =>
+      state.byDataID[dataID] ?? [],
+
+    getFiles: (state) => (dataID: string) =>
+      (state.byDataID[dataID] ?? []).map(pluck('file')),
   },
+
   actions: {
     remove(dataID: string) {
       if (dataID in this.byDataID) {
-        this.byDataID[dataID].forEach((file) => this.fileToRemote.delete(file));
+        // this.byDataID[dataID].forEach((file) => this.fileToRemote.delete(file));
         del(this.byDataID, dataID);
       }
     },
-    add(dataID: string, files: File[]) {
+
+    add(dataID: string, files: DatasetFile[]) {
       set(this.byDataID, dataID, files);
     },
 

--- a/src/store/datasets-files.ts
+++ b/src/store/datasets-files.ts
@@ -5,7 +5,7 @@ import { pluck } from '../utils';
 export type DatasetPath = string & { __type: 'DatasetPath' };
 export type DatasetUrl = string & { __type: 'DatasetUrl' };
 export type LocalDatasetFile = { file: File };
-export type ZipDatasetFile = LocalDatasetFile & { path: string };
+export type ZipDatasetFile = LocalDatasetFile & { archivePath: string };
 export type RemoteDatasetFile = LocalDatasetFile & {
   url: DatasetUrl;
   remoteFilename: string;

--- a/src/store/datasets-files.ts
+++ b/src/store/datasets-files.ts
@@ -61,9 +61,11 @@ export const useFileStore = defineStore('files', {
   }),
 
   getters: {
+    // Returns [DatasetFile] used to build a dataID
     getDatasetFiles: (state) => (dataID: string) =>
       state.byDataID[dataID] ?? [],
 
+    // Returns [File] used to build a dataID
     getFiles: (state) => (dataID: string) =>
       (state.byDataID[dataID] ?? []).map(pluck('file')),
   },

--- a/src/store/datasets-files.ts
+++ b/src/store/datasets-files.ts
@@ -5,7 +5,10 @@ import { pluck } from '../utils';
 export type DatasetUrl = string & { __type: 'UrlString' };
 export type LocalDatasetFile = { file: File };
 export type ZipDatasetFile = LocalDatasetFile & { path: string };
-export type RemoteDatasetFile = LocalDatasetFile & { url: DatasetUrl };
+export type RemoteDatasetFile = LocalDatasetFile & {
+  url: DatasetUrl;
+  remoteFilename: string;
+};
 export type DatasetFile =
   | LocalDatasetFile
   | ZipDatasetFile
@@ -16,16 +19,10 @@ export const makeLocal = (file: File) => ({
   file,
 });
 
-export const makeZip =
-  (path = '') =>
-  (file: File) => ({
-    file,
-    path,
-  });
-
-export const makeRemote = (url: DatasetUrl | string) => (file: File) => ({
+export const makeRemote = (url: DatasetUrl | string, file: File) => ({
   file,
   url: url as DatasetUrl,
+  remoteFilename: file.name,
 });
 
 export const isRemote = (

--- a/src/store/datasets-files.ts
+++ b/src/store/datasets-files.ts
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia';
 
 interface State {
   byDataID: Record<string, File[]>;
+  fileToRemote: Map<File, string>;
 }
 
 /**
@@ -11,6 +12,7 @@ interface State {
 export const useFileStore = defineStore('files', {
   state: (): State => ({
     byDataID: {},
+    fileToRemote: new Map(),
   }),
   getters: {
     getFiles: (state) => {
@@ -25,11 +27,16 @@ export const useFileStore = defineStore('files', {
   actions: {
     remove(dataID: string) {
       if (dataID in this.byDataID) {
+        this.byDataID[dataID].forEach((file) => this.fileToRemote.delete(file));
         del(this.byDataID, dataID);
       }
     },
     add(dataID: string, files: File[]) {
       set(this.byDataID, dataID, files);
+    },
+
+    addRemote(file: File, url: string) {
+      this.fileToRemote.set(file, url);
     },
   },
 });

--- a/src/store/datasets-files.ts
+++ b/src/store/datasets-files.ts
@@ -3,17 +3,14 @@ import { defineStore } from 'pinia';
 import { pluck } from '../utils';
 
 export type DatasetUrl = string & { __type: 'UrlString' };
-export type LocalDatasetFileMeta = { file: { name: string } };
-export type ZipDatasetFileMeta = LocalDatasetFileMeta & { path: string };
-export type RemoteDatasetFileMeta = ZipDatasetFileMeta & { url: DatasetUrl };
-export type DatasetFileMeta =
-  | LocalDatasetFileMeta
-  | ZipDatasetFileMeta
-  | RemoteDatasetFileMeta;
-
-export type DatasetFile = DatasetFileMeta & {
-  file: File;
-};
+export type LocalDatasetFile = { file: File };
+export type ZipDatasetFile = LocalDatasetFile & { path: string };
+export type RemoteDatasetFile = LocalDatasetFile & { url: DatasetUrl };
+export type DatasetFile =
+  | LocalDatasetFile
+  | ZipDatasetFile
+  | RemoteDatasetFile
+  | (ZipDatasetFile & RemoteDatasetFile);
 
 export const makeLocal = (file: File) => ({
   file,
@@ -29,13 +26,12 @@ export const makeZip =
 export const makeRemote = (url: DatasetUrl | string) => (file: File) => ({
   file,
   url: url as DatasetUrl,
-  path: '',
 });
 
 export const isRemote = (
-  datasetFile: DatasetFileMeta
-): datasetFile is RemoteDatasetFileMeta =>
-  (datasetFile as RemoteDatasetFileMeta).url !== undefined;
+  datasetFile: DatasetFile
+): datasetFile is RemoteDatasetFile =>
+  (datasetFile as RemoteDatasetFile).url !== undefined;
 
 interface State {
   byDataID: Record<string, DatasetFile[]>;

--- a/src/store/datasets-files.ts
+++ b/src/store/datasets-files.ts
@@ -2,7 +2,8 @@ import { del, set } from '@vue/composition-api';
 import { defineStore } from 'pinia';
 import { pluck } from '../utils';
 
-export type DatasetUrl = string & { __type: 'UrlString' };
+export type DatasetPath = string & { __type: 'DatasetPath' };
+export type DatasetUrl = string & { __type: 'DatasetUrl' };
 export type LocalDatasetFile = { file: File };
 export type ZipDatasetFile = LocalDatasetFile & { path: string };
 export type RemoteDatasetFile = LocalDatasetFile & {
@@ -19,11 +20,28 @@ export const makeLocal = (file: File) => ({
   file,
 });
 
-export const makeRemote = (url: DatasetUrl | string, file: File) => ({
-  file,
-  url: url as DatasetUrl,
-  remoteFilename: file.name,
-});
+export const makeZip = (
+  path: DatasetUrl | string,
+  file: File | DatasetFile
+) => {
+  const isFile = file instanceof File;
+  return {
+    path: path as DatasetPath,
+    ...(isFile ? { file } : file),
+  };
+};
+
+export const makeRemote = (
+  url: DatasetUrl | string,
+  file: File | DatasetFile
+) => {
+  const isFile = file instanceof File;
+  return {
+    url: url as DatasetUrl,
+    remoteFilename: isFile ? file.name : file.file.name,
+    ...(isFile ? { file } : file),
+  };
+};
 
 export const isRemote = (
   datasetFile: DatasetFile

--- a/src/store/datasets-images.ts
+++ b/src/store/datasets-images.ts
@@ -6,10 +6,10 @@ import { Bounds } from '@kitware/vtk.js/types';
 
 import { defaultLPSDirections, getLPSDirections } from '../utils/lps';
 import { removeFromArray } from '../utils';
-import { StateFile, DataSetType, DataSet } from '../io/state-file/schema';
+import { StateFile, DatasetType } from '../io/state-file/schema';
 import { serializeData } from '../io/state-file/utils';
 import { FILE_READERS } from '../io';
-import { useFileStore } from './datasets-files';
+import { DatasetFile, useFileStore } from './datasets-files';
 import { LPSDirections } from '../types/lps';
 
 export interface ImageMetadata {
@@ -96,10 +96,11 @@ export const useImageStore = defineStore('images', {
       // input files in fileStore with matching imageID.)
       const dataIDs = this.idList.filter((id) => id in fileStore.byDataID);
 
-      await serializeData(stateFile, dataIDs, DataSetType.IMAGE);
+      await serializeData(stateFile, dataIDs, DatasetType.IMAGE);
     },
 
-    async deserialize(dataSet: DataSet, file: File) {
+    async deserialize(datasetFile: DatasetFile) {
+      const { file } = datasetFile;
       const reader = FILE_READERS.get(file.type);
       if (reader) {
         const dataObj = await reader(
@@ -107,7 +108,7 @@ export const useImageStore = defineStore('images', {
         );
         if (dataObj.isA('vtkImageData')) {
           const id = this.addVTKImageData(file.name, dataObj as vtkImageData);
-
+          useFileStore().add(id, [datasetFile]);
           return id;
         }
       }

--- a/src/store/datasets-labelmaps.ts
+++ b/src/store/datasets-labelmaps.ts
@@ -111,11 +111,13 @@ export const useLabelmapStore = defineStore('labelmap', {
       labelMaps.forEach(async (labelMap) => {
         const [file] = stateFiles
           .filter(
-            (entry) => `${entry.path}${entry.file.name}` === labelMap.path
+            (entry) =>
+              `${entry.archivePath}${entry.file.name}` === labelMap.path
           )
           .map((entry) => entry.file);
 
         // map parent id to new id
+        // eslint-disable-next-line no-param-reassign
         labelMap.parent = dataIDMap[labelMap.parent];
 
         const { parent } = labelMap;

--- a/src/store/datasets.ts
+++ b/src/store/datasets.ts
@@ -19,14 +19,14 @@ export const DataType = {
 };
 
 const makeFileSuccessStatus = (
-  filename: string,
+  file: File | string,
   type: 'model' | 'image',
   dataID: string
 ) =>
   ({
     type: 'file',
     loaded: true,
-    filename,
+    filename: typeof file === 'string' ? file : file.name,
     dataID,
     dataType: type,
   } as const);
@@ -198,7 +198,7 @@ export const useDatasetStore = defineStore('dataset', () => {
       await Promise.all(
         manifestFiles.map(async (file) => {
           try {
-            allFiles.push(...(await readRemoteManifestFile(file)));
+            allFiles.push(...(await readRemoteManifestFile(file.file)));
           } catch (err) {
             manifestStatuses.push(
               makeFileFailureStatus(
@@ -240,7 +240,7 @@ export const useDatasetStore = defineStore('dataset', () => {
               );
               fileStore.add(id, [datasetFile]);
 
-              return makeFileSuccessStatus(file.name, 'image', id);
+              return makeFileSuccessStatus(file, 'image', id);
             }
             if (dataObj.isA('vtkPolyData')) {
               const id = modelStore.addVTKPolyData(
@@ -249,7 +249,7 @@ export const useDatasetStore = defineStore('dataset', () => {
               );
               fileStore.add(id, [datasetFile]);
 
-              return makeFileSuccessStatus(file.name, 'model', id);
+              return makeFileSuccessStatus(file, 'model', id);
             }
             return makeFileFailureStatus(
               file,
@@ -305,7 +305,7 @@ export const useDatasetStore = defineStore('dataset', () => {
     const { file } = datasetFile;
     return imageStore
       .deserialize(datasetFile)
-      .then((dataID) => makeFileSuccessStatus(file.name, 'image', dataID))
+      .then((dataID) => makeFileSuccessStatus(file, 'image', dataID))
       .catch((err) =>
         makeFileFailureStatus(
           file.name,

--- a/src/store/dicom-web/dicom-web-store.ts
+++ b/src/store/dicom-web/dicom-web-store.ts
@@ -15,6 +15,7 @@ import {
   retrieveStudyMetadata,
   retrieveSeriesMetadata,
 } from '../../core/dicom-web-api';
+import { makeLocal } from '../datasets-files';
 
 export type ProgressState = 'Remote' | 'Pending' | 'Error' | 'Done';
 
@@ -168,7 +169,7 @@ export const useDicomWebStore = defineStore('dicom-web', () => {
         progressCallback
       );
       if (files) {
-        const [loadResult] = await datasets.loadFiles(files);
+        const [loadResult] = await datasets.loadFiles(files.map(makeLocal));
         if (loadResult?.loaded) {
           const selection = convertSuccessResultToDataSelection(loadResult);
           datasets.setPrimarySelection(selection);

--- a/src/store/view-configs/common.ts
+++ b/src/store/view-configs/common.ts
@@ -45,7 +45,7 @@ export const serializeViewConfig = <K extends ViewConfigStateKey>(
   configGetter: ViewConfigGetter,
   viewConfigStateKey: K
 ) => {
-  const dataIDs = stateFile.manifest.dataSets.map((dataSet) => dataSet.id);
+  const dataIDs = stateFile.manifest.datasets.map((dataset) => dataset.id);
   const { views } = stateFile.manifest;
 
   views.forEach((view) => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -58,6 +58,10 @@ export async function fetchFile(
   return new File([blob], name);
 }
 
+export const isFulfilled = <T>(
+  input: PromiseSettledResult<T>
+): input is PromiseFulfilledResult<T> => input.status === 'fulfilled';
+
 type PromiseResolveFunction<T> = (value: T) => void;
 type PromiseRejectFunction = (reason?: Error) => void;
 export interface Deferred<T> {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -100,6 +100,45 @@ export function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K> {
   return keys.reduce((o, k) => ({ ...o, [k]: obj[k] }), {} as Pick<T, K>);
 }
 
+export const pluck =
+  <T, K extends keyof T>(key: K) =>
+  (obj: T): T[K] =>
+    obj[key];
+
+/**
+ * Takes a predicate and a list of values and returns a a tuple (2-item array),
+ *  with each item containing the subset of the list that matches the predicate
+ *  and the complement of the predicate respectively
+ *
+ * @sig (T -> Boolean, T[]) -> [T[], T[]]
+ *
+ * @param {Function} predicate A predicate to determine which side the element belongs to.
+ * @param {Array} arr The list to partition
+ *
+ * Inspired by the Ramda function of the same name
+ * @see https://ramdajs.com/docs/#partition
+ *
+ * @example
+ *
+ *     const isNegative: (n: number) => boolean = n => n < 0
+ *     const numbers = [1, 2, -4, -7, 4, 22]
+ *     partition(isNegative, numbers)
+ *     // => [ [-4, -7], [1, 2, 4, 22] ]
+ *
+ * Source https://gist.github.com/zachlysobey/71ac85046d0d533287ed85e1caa64660
+ */
+export function partition<T>(
+  predicate: (val: T) => boolean,
+  arr: Array<T>
+): [Array<T>, Array<T>] {
+  const partitioned: [Array<T>, Array<T>] = [[], []];
+  arr.forEach((val: T) => {
+    const partitionIndex: 0 | 1 = predicate(val) ? 0 : 1;
+    partitioned[partitionIndex].push(val);
+  });
+  return partitioned;
+}
+
 export function plural(n: number, word: string, pluralWord?: string) {
   return n > 1 ? pluralWord ?? `${word}s` : word;
 }


### PR DESCRIPTION
### New Features
- Loads a `session.volview.zip` state file if in `files` URL parameter.
- Fetch remotely loaded datasets from URLs in state file, rather than zipping in all files.

### How
- Introduce `DatasetFile` type with copyleft `{ url, remoteFilename }` properties.  
- Files downloaded from url parameters, JSON manifest files, and sample datasets get wrapped as a `DatasetFile`.  
- `datasets-dicom` and `datasets-images` eventualy pass `DatasetFile`s to `datasets-files`.
 - On Save State: DatasetFiles with `url` and `remoteFilename` are saved as "Remote Datasets" in the JSON manifest and their raw data is not zipped into the state file.  `state-file/utils.ts` does this and is effectively has `datasets-files`' serialize and deserialize functions.

### Test Plan

For each scenario, verify:
- Save session has no errors
- Remote datasets are not included in .zip
- Load session zip file has no errors and state is restored

Scenarios
- [ ] Multiple uncompressed remote DICOM files
- [ ] Multiple zipped remote DICOM files

Also:
- [ ] A session zip file is loaded when pointed to by URL files parameter
- [ ] Load files from JSON manifest, save session, verify files are not in zip, verify session zip file loads.
