### PR TITLE
fix(async): use built-in URL api

### DIFF
--- a/src/io/vtk/async.ts
+++ b/src/io/vtk/async.ts
@@ -1,5 +1,4 @@
 import vtk from '@kitware/vtk.js/vtk';
-import { URL } from 'whatwg-url';
 
 import PromiseWorker from '@/src/utils/promise-worker';
 import vtkDataSet from '@kitware/vtk.js/Common/DataModel/DataSet';


### PR DESCRIPTION
Avoids this error when saving labelmaps:

`Refused to execute script from 'http://localhost:8081/5ccc414e5c4232d9.ts' because its MIME type ('video/mp2t') is not executable.`