### PR TITLE
Fix restore labelmaps and rulers on DICOMS

### DIFF
--- a/src/io/state-file/index.ts
+++ b/src/io/state-file/index.ts
@@ -26,7 +26,7 @@ import { Manifest, ManifestSchema } from './schema';
 import { deserializeDatasetFiles } from './utils';
 
 const MANIFEST = 'manifest.json';
-const VERSION = '0.0.3';
+const VERSION = '0.0.4';
 
 export async function save(fileName: string) {
   const datasetStore = useDatasetStore();
@@ -116,8 +116,11 @@ async function restore(state: FileEntry[]): Promise<LoadResult[]> {
     // eslint-disable-next-line no-await-in-loop
     const status = await datasetStore
       .deserialize(dataset, files)
-      .then((result) => {
+      .then(async (result) => {
         if (result.loaded) {
+          if (result.type === 'dicom')
+            // generate imageID so rulers and labelmaps can use stateIDToStoreID to setup there internal imageStore imageID references
+            await dicomStore.buildVolume(result.dataID);
           stateIDToStoreID[dataset.id] = result.dataID;
         }
 

--- a/src/store/datasets-labelmaps.ts
+++ b/src/store/datasets-labelmaps.ts
@@ -8,6 +8,7 @@ import { LABELMAP_PALETTE } from '../config';
 import { StateFile, Manifest } from '../io/state-file/schema';
 import { vtiReader, vtiWriter } from '../io/vtk/async';
 import { FileEntry } from '../io/types';
+import { findImageID, getDataID } from './datasets';
 
 const LabelmapArrayType = Uint8Array;
 export type LabelmapArrayType = Uint8Array;
@@ -87,7 +88,7 @@ export const useLabelmapStore = defineStore('labelmap', {
       await Promise.all(
         Object.entries(this.labelmaps).map(async ([id, labelMap]) => {
           const labelPath = `labels/${id}.vti`;
-          const parent = this.parentImage[id];
+          const parent = getDataID(this.parentImage[id]);
           labelMaps.push({
             id,
             parent,
@@ -127,7 +128,7 @@ export const useLabelmapStore = defineStore('labelmap', {
         const imageData = await vtiReader(file);
         const labelMapObj = toLabelMap(imageData as vtkImageData);
         this.idList.push(id);
-        set(this.parentImage, id, parent);
+        set(this.parentImage, id, findImageID(parent));
         set(this.labelmaps, id, labelMapObj);
         this.$proxies.addData(id, labelMapObj);
       });

--- a/src/store/datasets.ts
+++ b/src/store/datasets.ts
@@ -108,7 +108,6 @@ export const getImage = async (selection: DataSelection) => {
 };
 
 // Converts imageID to VolumeKey if exists, else return input imageID
-// @deprecated prefer imageID unless DICOM tags are needed
 export const getDataID = (imageID: string) => {
   const dicomStore = useDICOMStore();
   return dicomStore.imageIDToVolumeKey[imageID] ?? imageID;

--- a/src/store/datasets.ts
+++ b/src/store/datasets.ts
@@ -87,7 +87,7 @@ export type DataSelection = DICOMSelection | ImageSelection;
 export const getImageID = (selection: DataSelection) => {
   if (selection.type === 'image') return selection.dataID;
   if (selection.type === 'dicom')
-    return useDICOMStore().volumeToImageID[selection.volumeKey];
+    return useDICOMStore().volumeToImageID[selection.volumeKey]; // volume selected, but image may not have been made yet
 
   const _exhaustiveCheck: never = selection;
   throw new Error(`invalid selection type ${_exhaustiveCheck}`);
@@ -101,8 +101,23 @@ export const getImage = async (selection: DataSelection) => {
     await useErrorMessage('Failed to build volume', () =>
       dicoms.buildVolume(selection.volumeKey)
     );
+    return images.dataIndex[getImageID(selection)!];
   }
-  return images.dataIndex[getImageID(selection)!];
+  // just an image that should be in dataIndex
+  return images.dataIndex[selection.dataID];
+};
+
+// Converts imageID to VolumeKey if exists, else return input imageID
+// @deprecated prefer imageID unless DICOM tags are needed
+export const getDataID = (imageID: string) => {
+  const dicomStore = useDICOMStore();
+  return dicomStore.imageIDToVolumeKey[imageID] ?? imageID;
+};
+
+// Pass VolumeKey or ImageID and get ImageID
+export const findImageID = (dataID: string) => {
+  const dicomStore = useDICOMStore();
+  return dicomStore.volumeToImageID[dataID] ?? dataID;
 };
 
 export function selectionEquals(s1: DataSelection, s2: DataSelection) {

--- a/src/store/tools/index.ts
+++ b/src/store/tools/index.ts
@@ -85,7 +85,7 @@ export const useToolStore = defineStore('tool', {
       const paintStore = usePaintToolStore();
       const cropStore = useCropStore();
 
-      rulerStore.deserialize(manifest);
+      rulerStore.deserialize(manifest, dataIDMap);
       crosshairsStore.deserialize(manifest);
       paintStore.deserialize(manifest, labelmapIDMap);
       cropStore.deserialize(manifest, dataIDMap);


### PR DESCRIPTION
Label maps and rulers would not load on DICOM files after serialization.  Their serialized representation hold the imageStore ID but datasets are serialized under VolumeKey or ImageID.

Down the line might be good to move to a `DatasetID` generated by `dataset.ts` that annotations, view configs, serialization use no matter the image type.  Or we slowly annotations and serialization to using `DataSelection`