### PR TITLE
fix(io): avoid error when loading a zip in a zip

### DIFF
--- a/src/io/io.ts
+++ b/src/io/io.ts
@@ -1,6 +1,6 @@
 import { extensionToImageIO } from 'itk-wasm';
 import { extractFilesFromZip } from './zip';
-import { DatasetFile, ZipDatasetFile } from '../store/datasets-files';
+import { DatasetFile } from '../store/datasets-files';
 import { partition } from '../utils';
 
 export const ARCHIVE_FILE_TYPES = new Set(['zip', 'application/zip']);
@@ -104,11 +104,9 @@ export async function extractArchivesRecursively(
   const unzipped = await Promise.all(
     archives.flatMap(async (zip) => {
       const entries = await extractFilesFromZip(zip.file);
-      const zipArchivePath = (zip as ZipDatasetFile).archivePath ?? '';
-      return entries.map(({ file, archivePath }) => ({
-        ...zip, // preserve DatasetFile remote provenance
-        archivePath: `${zipArchivePath}/${archivePath}`,
-        file,
+      return entries.map((datasetFileWithPath) => ({
+        ...zip, // preserve zip's remote provenance
+        ...datasetFileWithPath,
       }));
     })
   );

--- a/src/store/datasets-files.ts
+++ b/src/store/datasets-files.ts
@@ -5,7 +5,7 @@ import { pluck } from '../utils';
 export type DatasetPath = string & { __type: 'DatasetPath' };
 export type DatasetUrl = string & { __type: 'DatasetUrl' };
 export type LocalDatasetFile = { file: File };
-export type ZipDatasetFile = LocalDatasetFile & { archivePath: string };
+export type ZipDatasetFile = LocalDatasetFile & { archivePath: DatasetPath };
 export type RemoteDatasetFile = LocalDatasetFile & {
   url: DatasetUrl;
   remoteFilename: string;
@@ -19,17 +19,6 @@ export type DatasetFile =
 export const makeLocal = (file: File) => ({
   file,
 });
-
-export const makeZip = (
-  path: DatasetUrl | string,
-  file: File | DatasetFile
-) => {
-  const isFile = file instanceof File;
-  return {
-    path: path as DatasetPath,
-    ...(isFile ? { file } : file),
-  };
-};
 
 export const makeRemote = (
   url: DatasetUrl | string,


### PR DESCRIPTION
With nested zip files, the original zip file would get mixed in with the extracted files, resulting in an Error: cannot find reader for .zip

Test file with nested zip.
[zip-in-zip.zip](https://github.com/Kitware/VolView/files/11182269/zip-in-zip.zip)

Also, remove unused and buggy makeZip()
