### PR TITLE
fix(volume-coloring): opacity range is image range

### DIFF
--- a/src/store/view-configs/volume-coloring.ts
+++ b/src/store/view-configs/volume-coloring.ts
@@ -5,7 +5,6 @@ import vtkPiecewiseFunctionProxy from '@kitware/vtk.js/Proxy/Core/PiecewiseFunct
 import {
   getColorFunctionRangeFromPreset,
   getOpacityFunctionFromPreset,
-  getOpacityRangeFromPreset,
 } from '@/src/utils/vtk-helpers';
 import { DEFAULT_PRESET_BY_MODALITY } from '@/src/config';
 import { ColorTransferFunction } from '@/src/types/views';
@@ -142,8 +141,7 @@ export const setupVolumeColorConfig = () => {
     updateVolumeColorTransferFunction(viewID, imageID, ctFunc);
 
     const opFunc = getOpacityFunctionFromPreset(preset);
-    const opRange = getOpacityRangeFromPreset(preset);
-    opFunc.mappingRange = opRange || imageDataRange;
+    opFunc.mappingRange = imageDataRange;
     updateVolumeOpacityFunction(viewID, imageID, opFunc);
   };
 


### PR DESCRIPTION
Do not use the opacity function's range. Instead, rescale it to the dataset range.