### PR TITLE
DICOMWeb fixes for Google hosted service

### DIFF
--- a/src/core/dicom-web-api.ts
+++ b/src/core/dicom-web-api.ts
@@ -47,11 +47,21 @@ function parseTag(value: any) {
   return v;
 }
 
-function parseInstance(instance: any): Instance {
-  return Object.entries(tags).reduce(
+// remove undefined properties
+function cleanUndefined(obj: Object) {
+  return Object.entries(obj).reduce(
+    (cleaned, [key, value]) =>
+      value === undefined ? cleaned : { ...cleaned, [key]: value },
+    {}
+  );
+}
+
+function parseInstance(instance: any) {
+  const withNamedTags = Object.entries(tags).reduce(
     (info, [key, tag]) => ({ ...info, [key]: parseTag(instance[tag]) }),
     {}
-  ) as Instance;
+  );
+  return cleanUndefined(withNamedTags) as Instance;
 }
 
 // Create unique file names so loader utils work

--- a/src/core/dicom-web-api.ts
+++ b/src/core/dicom-web-api.ts
@@ -122,7 +122,6 @@ export async function fetchInstanceThumbnail(
   const thumbnail = await client.retrieveInstanceRendered({
     ...instance,
     mediaTypes: [{ mediaType: 'image/jpeg' }],
-    queryParams: { quality: '10' },
   });
   const arrayBufferView = new Uint8Array(thumbnail);
   const blob = new Blob([arrayBufferView], { type: 'image/jpeg' });

--- a/src/store/dicom-web/dicom-web-store.ts
+++ b/src/store/dicom-web/dicom-web-store.ts
@@ -1,6 +1,8 @@
 import { computed, ref, set } from '@vue/composition-api';
-import { useLocalStorage } from '@vueuse/core';
+import { useLocalStorage, UrlParams } from '@vueuse/core';
 import { defineStore } from 'pinia';
+import vtkURLExtract from '@kitware/vtk.js/Common/Core/URLExtract';
+
 import {
   convertSuccessResultToDataSelection,
   useDatasetStore,
@@ -43,9 +45,14 @@ async function getAllPatients(host: string): Promise<PatientInfo[]> {
  * Collect DICOM data from DICOMWeb
  */
 export const useDicomWebStore = defineStore('dicom-web', () => {
-  const host = process.env.VUE_APP_DICOM_WEB_URL
-    ? ref(process.env.VUE_APP_DICOM_WEB_URL)
+  const urlParams = vtkURLExtract.extractURLParameters() as UrlParams;
+  const dicomWebFromURLParam = urlParams.dicomweb as string | undefined;
+  const initialHost = dicomWebFromURLParam ?? process.env.VUE_APP_DICOM_WEB_URL;
+
+  const host = initialHost
+    ? ref(initialHost)
     : useLocalStorage<string | null>('dicomWebHost', ''); // null if cleared by vuetify text input
+
   // Remove trailing slash
   const cleanHost = computed(() => host.value?.replace(/\/$/, '') ?? '');
   const isConfigured = computed(() => !!cleanHost.value);


### PR DESCRIPTION
- Remove trailing slash if on host URL
- Support minimal metadata responses
- Add a `dicomweb=http://localhost:5173/dicom-web` URL parameter to configure default host