### PR TITLE
Support downloading from Google Cloud Storage URIs

### DIFF
--- a/documentation/content/doc/loading_data.md
+++ b/documentation/content/doc/loading_data.md
@@ -25,6 +25,17 @@ The URL is constructed with two parts, as shown below. The required parameter is
 https://volview.netlify.com/?<strong>names=[prostate-mri.zip,neck.mha]</strong>&<strong>urls=[https://data.kitware.com/api/v1/item/63527c7311dab8142820a338/download,https://data.kitware.com/api/v1/item/620db4b84acac99f42e75420/download]</strong>
 </pre>
 
+### Google Cloud Storage Bucket Support
+
+VolView supports Google Cloud Storage links of the form `gs://<bucket>/<object>`. VolView can either download a single object,
+or download everything underneath a given object prefix/folder. As an example, VolView will download and load every file that
+exists in the `gs://my-public-bucket/my-patient-folder/` folder.
+
+As a note of caution, there are no checks on the size of the total download. As such, be careful when specifying bucket-level prefixes!
+
+This feature currently only supports public buckets that are anonymously accessible. Authenticated support may be added at a future date.
+If you have a strong use-case for it, please request it via [our issue page](https://github.com/Kitware/VolView/issues)!
+
 ### CORS
 
 In order for VolView to download and display your remote datasets, your server must be configured with the correct [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) configuration. CORS is a browser security mechanism that restricts how web applications can access remote resources. Without proper CORS configuration, VolView will be unable to download and display your datasets. Configuring your web server with CORS is beyond the scope of this documentation; please refer to your server's documentation.

--- a/src/io/googleCloudStorage.ts
+++ b/src/io/googleCloudStorage.ts
@@ -1,0 +1,95 @@
+import { URL } from 'whatwg-url';
+import { fetchJSON } from '../utils/fetch';
+
+export interface GcsObject {
+  kind: string;
+  id: string;
+  selfLink: string;
+  mediaLink: string;
+  name: string;
+  bucket: string;
+  size: string;
+}
+
+interface GcsObjectListResult {
+  kind: string;
+  nextPageToken?: string;
+  items: GcsObject[];
+}
+
+/**
+ * Detects `gs://` uri.
+ * @param uri
+ * @returns
+ */
+export const isGoogleCloudStorageUri = (uri: string) =>
+  new URL(uri).protocol === 'gs:';
+
+/**
+ * Extracts bucket and prefix from `gs://` URIs
+ * @param uri
+ * @returns
+ */
+export const extractBucketAndPrefixFromGsUri = (uri: string) => {
+  const { hostname: bucket, pathname } = new URL(uri);
+  // drop the leading forward slash
+  const objectName = pathname.replace(/^\//, '');
+  return [bucket, objectName] as const;
+};
+
+export type ObjectAvailableCallback = (object: GcsObject) => void;
+
+const getObjectEndpoint = (bucket: string) =>
+  `https://storage.googleapis.com/storage/v1/b/${bucket}/o`;
+
+async function fetchObjectsWithPagination(
+  bucket: string,
+  prefix: string,
+  onObjectAvailable: ObjectAvailableCallback = () => {}
+) {
+  const objects: GcsObject[] = [];
+
+  const paginate = async (nextToken?: string) => {
+    const url = new URL(getObjectEndpoint(bucket));
+    url.searchParams.append('prefix', prefix);
+    url.searchParams.append('maxResults', '1000');
+    if (nextToken) {
+      url.searchParams.append('pageToken', nextToken);
+    }
+
+    const page = await fetchJSON<GcsObjectListResult>(url.toString());
+    if (page.kind !== 'storage#objects') {
+      throw new Error('GCS did not return a list of objects!');
+    }
+
+    objects.push(...page.items);
+    page.items.forEach((obj) => onObjectAvailable(obj));
+
+    if (page.nextPageToken) {
+      await paginate(page.nextPageToken);
+    }
+  };
+
+  await paginate();
+  return objects;
+}
+
+/**
+ * Gets all objects from a given gs:// URI.
+ *
+ * This is a simplified entrypoint for GCS. We're not using
+ * @google-cloud/storage due to node dependencies. As such, this will most
+ * definitely be incomplete (slight API missteps, no retries, etc.) For the
+ * purpose of just downloading datasets, it should work just fine.
+ *
+ * @param gsUri
+ * @param onObjectAvailable
+ * @returns
+ */
+export const getObjectsFromGsUri = async (
+  gsUri: string,
+  onObjectAvailable: ObjectAvailableCallback = () => {}
+) => {
+  const [bucketName, objPrefix] = extractBucketAndPrefixFromGsUri(gsUri);
+  return fetchObjectsWithPagination(bucketName, objPrefix, onObjectAvailable);
+};


### PR DESCRIPTION
This adds support for `gs://<bucket>/<object prefix>` URIs. It will download all of the objects with the given object prefix and then attempt to load them.

Todo:
- [x] add documentation
- [x] wait for #314