### PR TITLE
fix(io): Remove private qualifier initialize method in DICOMIO Class

### DIFF
--- a/src/io/dicom.ts
+++ b/src/io/dicom.ts
@@ -47,7 +47,7 @@ export class DICOMIO {
    * @async
    * @throws Error initialization failed
    */
-  private async initialize() {
+  async initialize() {
     if (!this.initializeCheck) {
       this.initializeCheck = new Promise<void>((resolve, reject) => {
         this.runTask('dicom', [], [], [])


### PR DESCRIPTION
The 'initialize()' method, which was declared with a 'private' qualifier inside the DICOMIO class, is being called from outside and thus the 'private' qualifier is removed.