### PR TITLE
DICOMWeb deep addresses

### DIFF
--- a/src/components/DataBrowser.vue
+++ b/src/components/DataBrowser.vue
@@ -144,7 +144,7 @@ export default defineComponent({
         >
           <v-expansion-panel-header>
             <v-icon class="collection-header-icon">mdi-cloud-download</v-icon>
-            <span>
+            <span class="text-truncate">
               {{ `${dicomWeb.hostName || dicomWeb.host} | DICOMWeb` }}
             </span>
           </v-expansion-panel-header>

--- a/src/components/dicom-web/DicomWebSettings.vue
+++ b/src/components/dicom-web/DicomWebSettings.vue
@@ -19,7 +19,7 @@ export default defineComponent({
     onUnmounted(() => {
       // Re-fetch if address changed or an error message exists
       if (hostAtStart.value !== dicomWeb.host || dicomWeb.message)
-        dicomWeb.fetchPatients();
+        dicomWeb.fetchInitialDicoms();
     });
 
     return {

--- a/src/components/dicom-web/PatientList.vue
+++ b/src/components/dicom-web/PatientList.vue
@@ -1,8 +1,10 @@
 <script lang="ts">
 import { computed, defineComponent } from '@vue/composition-api';
 
+import { useDicomWebStore } from '@/src/store/dicom-web/dicom-web-store';
+import { useDicomMetaStore } from '@/src/store/dicom-web/dicom-meta-store';
+
 import PatientDetails from './PatientDetails.vue';
-import { useDicomWebStore } from '../../store/dicom-web/dicom-web-store';
 
 export default defineComponent({
   components: {
@@ -10,10 +12,11 @@ export default defineComponent({
   },
   setup() {
     const dicomWeb = useDicomWebStore();
+    const dicomWebMeta = useDicomMetaStore();
     dicomWeb.fetchPatientsOnce();
 
     const patients = computed(() =>
-      dicomWeb.patients
+      Object.values(dicomWebMeta.patientInfo)
         .map((info) => ({
           key: info.PatientID,
           name: info.PatientName,

--- a/src/components/dicom-web/PatientList.vue
+++ b/src/components/dicom-web/PatientList.vue
@@ -13,7 +13,7 @@ export default defineComponent({
   setup() {
     const dicomWeb = useDicomWebStore();
     const dicomWebMeta = useDicomMetaStore();
-    dicomWeb.fetchPatientsOnce();
+    dicomWeb.fetchInitialDicomsOnce();
 
     const patients = computed(() =>
       Object.values(dicomWebMeta.patientInfo)

--- a/src/store/dicom-web/dicom-meta-store.ts
+++ b/src/store/dicom-web/dicom-meta-store.ts
@@ -180,7 +180,9 @@ export const useDicomMetaStore = defineStore('dicom-meta', {
         this.volumeInfo[volumeKey].NumberOfSlices += 1;
       }
 
-      // clean orphaned patients
+      // Clean orphaned patients. Anonymous Patient loses its only study
+      // when slices are loaded with full DICOM tags. Study was anonymous
+      // because url deep linked into a study
       Object.entries(this.patientStudies).forEach(([key, studies]) => {
         if (studies.length === 0) {
           this.deletePatient(key);

--- a/src/store/dicom-web/dicom-meta-store.ts
+++ b/src/store/dicom-web/dicom-meta-store.ts
@@ -1,4 +1,4 @@
-import { set } from '@vue/composition-api';
+import { del, set } from '@vue/composition-api';
 import { defineStore } from 'pinia';
 import {
   ANONYMOUS_PATIENT,
@@ -7,7 +7,7 @@ import {
   StudyInfo,
   VolumeInfo,
 } from '../datasets-dicom';
-import { pick } from '../../utils';
+import { pick, removeFromArray } from '../../utils';
 import { Instance } from '../../core/dicom-web-api';
 
 interface InstanceInfo {
@@ -20,11 +20,6 @@ interface InstanceInfo {
 type VolumeInfoForUi = Omit<VolumeInfo, 'layers'>;
 
 interface State {
-  // volumeKey -> imageID
-  volumeToImageID: Record<string, string>;
-  // imageID -> volumeKey
-  imageIDToVolumeKey: Record<string, string>;
-
   // volume invalidation information
   needsRebuild: Record<string, boolean>;
 
@@ -57,8 +52,6 @@ interface State {
 
 export const useDicomMetaStore = defineStore('dicom-meta', {
   state: (): State => ({
-    volumeToImageID: {},
-    imageIDToVolumeKey: {},
     patientInfo: {},
     patientStudies: {},
     studyInfo: {},
@@ -111,6 +104,45 @@ export const useDicomMetaStore = defineStore('dicom-meta', {
       this._updateDatabase(patient, study, volumeInfo, instanceInfo);
     },
 
+    deleteVolume(volumeKey: string) {
+      if (volumeKey in this.volumeInfo) {
+        const studyKey = this.volumeStudy[volumeKey];
+        del(this.volumeInfo, volumeKey);
+        del(this.volumeStudy, volumeKey);
+
+        removeFromArray(this.studyVolumes[studyKey], volumeKey);
+        if (this.studyVolumes[studyKey].length === 0) {
+          this.deleteStudy(studyKey);
+        }
+      }
+    },
+
+    deleteStudy(studyKey: string) {
+      if (studyKey in this.studyInfo) {
+        const patientKey = this.studyPatient[studyKey];
+        del(this.studyInfo, studyKey);
+        del(this.studyPatient, studyKey);
+
+        del(this.studyVolumes, studyKey);
+
+        removeFromArray(this.patientStudies[patientKey], studyKey);
+        if (this.patientStudies[patientKey].length === 0) {
+          this.deletePatient(patientKey);
+        }
+      }
+    },
+
+    deletePatient(patientKey: string) {
+      if (patientKey in this.patientInfo) {
+        del(this.patientInfo, patientKey);
+
+        [...this.patientStudies[patientKey]].forEach((studyKey) =>
+          this.deleteStudy(studyKey)
+        );
+        del(this.patientStudies, patientKey);
+      }
+    },
+
     _updateDatabase(
       patient: PatientInfo,
       study: StudyInfo,
@@ -147,6 +179,13 @@ export const useDicomMetaStore = defineStore('dicom-meta', {
 
         this.volumeInfo[volumeKey].NumberOfSlices += 1;
       }
+
+      // clean orphaned patients
+      Object.entries(this.patientStudies).forEach(([key, studies]) => {
+        if (studies.length === 0) {
+          this.deletePatient(key);
+        }
+      });
     },
   },
 });

--- a/src/store/dicom-web/dicom-web-store.ts
+++ b/src/store/dicom-web/dicom-web-store.ts
@@ -68,12 +68,15 @@ export const useDicomWebStore = defineStore('dicom-web', () => {
   const cleanHost = computed(() => {
     const sansSlash = host.value?.replace(/\/$/, '') ?? '';
     const tokenized = sansSlash.split('/');
+
     [studies, studyID] = tokenized.slice(-2);
     if (studies === 'studies' && studyID) {
       return tokenized.slice(0, -2).join('/');
     }
+
     return sansSlash;
   });
+
   const isConfigured = computed(() => !!cleanHost.value);
 
   const fetchError = ref<undefined | unknown>(undefined);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -205,3 +205,31 @@ export function roundIfCloseToInteger(value: number, eps = EPSILON) {
   }
   return value;
 }
+
+export function hasKey<O extends Object>(
+  obj: O,
+  key: PropertyKey
+): key is keyof O {
+  return key in obj;
+}
+
+export function remapKeys<O extends Object, K extends keyof O>(
+  obj: O,
+  keyMap: Record<K, K>
+) {
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => {
+      if (hasKey(keyMap, key)) return [keyMap[key], value];
+      throw new Error(`Key ${key} not found in keyMap`);
+    })
+  );
+}
+
+// return object without the given keys
+export const omit = <T extends Record<string, unknown>, K extends keyof T>(
+  obj: T,
+  keys: K[] | K
+) =>
+  Object.fromEntries(
+    Object.entries(obj).filter(([key]) => !wrapInArray(keys).includes(key as K))
+  ) as Omit<T, K>;


### PR DESCRIPTION
Can specify a study or a series on the DICOMWeb server with the URL.

For a study URL like `http://localhost:3000/dicom-web/studies/someid` VolView will show *just* that study in the data browser.

For a series URL like `http://localhost:3000/dicom-web/studies/someid/series/anotherid` VolView will automatically load the series as a volume .

Example url:
https://deploy-preview-327--volview-dev.netlify.app/?dicomweb=https://dicomweb.netlify.app/dicom-web/studies/1.3.6.1.4.1.14519.5.2.1.8421.4009.312603252934799756197864329946/series/1.3.6.1.4.1.14519.5.2.1.8421.4009.216553465756246417429199106507