### PR TITLE
Doc formatting

### DIFF
--- a/documentation/content/doc/loading_data.md
+++ b/documentation/content/doc/loading_data.md
@@ -1,4 +1,4 @@
-## title: Loading Data
+# Loading Data
 
 The most straightfoward way to load files into VolView is to drag-and-drop them onto the central window when viewing the "Data" tab. You can also click within the central window to open a file browser and select the files or folders the "Open" button on the top-right toolbar. To complement different use-cases, there are a few other ways to open files.
 

--- a/documentation/content/doc/loading_data.md
+++ b/documentation/content/doc/loading_data.md
@@ -10,9 +10,20 @@ VolView can load multiple DICOM files, folders containing multiple DICOM files, 
 
 VolView includes links to a variety of sample data. Clicking on those thumbnails in the Data tab will download that data from Kitware data.kitware.com website into your local machine.
 
-## DICOM Web
+## DICOMWeb
 
-DICOMWeb support is being added to VolView. It will allow data from compliant DICOMWeb servers to be browsed, searched, and downloaded into VolView with only a few clicks.
+VolView lists and downloads DICOM files served by a DICOMWeb service. The host address of the DICOMWeb service is configurable by:
+
+- VolView settings menu
+- `dicomweb` URL parameter. Example: `https://volview.netlify.com/?dicomweb=https://dicomweb-server.com`
+- At VolView build time with the `VUE_APP_DICOM_WEB_URL` environment variable.
+
+The DICOMWeb address can point to a specific series in a study, and VolView will
+automatically load the whole series. Example URL:
+
+```
+https://volview.netlify.com/?dicomweb=https://dicomweb-server.com/studies/unique-study-id-here/series/unique-series-id-here
+```
 
 ## Loading Remote Data via URLs
 
@@ -20,9 +31,9 @@ VolView supports loading remote datasets at application start through URL parame
 
 The URL is constructed with two parts, as shown below. The required parameter is the `urls` parameter, which specifies a list of URLs to download. An optional `names` parameter specifies the filename to go along with the file. If VolView cannot infer the file type, the filename's extension is used as a fallback. Loading multiple URLs is achieved by separating them with a comma.
 
-<pre>
-https://volview.netlify.com/?<strong>names=[prostate-mri.zip,neck.mha]</strong>&<strong>urls=[https://data.kitware.com/api/v1/item/63527c7311dab8142820a338/download,https://data.kitware.com/api/v1/item/620db4b84acac99f42e75420/download]</strong>
-</pre>
+```
+https://volview.netlify.com/?names=[prostate-mri.zip,neck.mha]&urls=[https://data.kitware.com/api/v1/item/63527c7311dab8142820a338/download,https://data.kitware.com/api/v1/item/620db4b84acac99f42e75420/download]
+```
 
 ### Google Cloud Storage Bucket and AWS S3 Support
 

--- a/documentation/content/doc/mouse_controls.md
+++ b/documentation/content/doc/mouse_controls.md
@@ -1,5 +1,4 @@
-title: Keyboard shortcuts
-----
+# Keyboard shortcuts
 
 <style>
 table {
@@ -9,23 +8,22 @@ table {
 
 ## Data management
 
-| Shortcut       | Action               |
-| -------------- | -------------------- |
+| Shortcut | Action |
+| -------- | ------ |
 
+## Slice
 
-## Slice 
-
-| Shortcut       | Action          |
-| -------------- | --------------- |
-| Up arrow       | Next Slice      |
-| Right arrow    | Next Slice      |
-| Down array     | Previous Slice  |
-| Left array     | Previous Slice  |
+| Shortcut    | Action         |
+| ----------- | -------------- |
+| Up arrow    | Next Slice     |
+| Right arrow | Next Slice     |
+| Down array  | Previous Slice |
+| Left array  | Previous Slice |
 
 ## Mouse Controls
 
 | Action       | 2D              | 3D     |
-| ------------ | --------------- | -------|
+| ------------ | --------------- | ------ |
 | Left         | grayscale       | rotate |
 | Mid          | pan             | pan    |
 | Right        | zoom            | zoom   |

--- a/documentation/content/doc/rendering.md
+++ b/documentation/content/doc/rendering.md
@@ -1,5 +1,4 @@
-title: Cinematic Volume Rendering
-----
+# Cinematic Volume Rendering
 
 <style>
 table {
@@ -7,21 +6,23 @@ table {
 }
 </style>
 
-VolView reads the DICOM tags of your data to determine appropriate preset parameter values for cinematic volume rendering for your data, but often you will want to tweak those presets to emphasize specific details.  We recommend the following sequence of tweaks to improve your visualizations.
+VolView reads the DICOM tags of your data to determine appropriate preset parameter values for cinematic volume rendering for your data, but often you will want to tweak those presets to emphasize specific details. We recommend the following sequence of tweaks to improve your visualizations.
 
-1. Cinematic volume rendering involves two "transfer functions": one maps the recorded intensity values (e.g., CT hounsfield units) to opacity and the other maps recorded intensity values to color.   Both can be adjusted using the controls at the top of the Rendering tab.   The graph at the top shows a histogram of the recorded intensity values in light gray and the current opacity transfer function as an overlaid curve in black.  In that graph, beneath the black curve, is a depiction of the color transfer function. ![Cinematic](../gallery/16-volview-rendering.jpg)
-    1. Begin by adjusting the opacity transfer function by a press-and-drag right/left on the top graph.  ![Opacity](../gallery/17-volview-opacity-notes.jpg)
-    2. Then adjust the color transfer function by moving the blue dots on the colorbar beneath the graph.  ![Color](../gallery/17-volview-colormap-notes.jpg)
+1. Cinematic volume rendering involves two "transfer functions": one maps the recorded intensity values (e.g., CT hounsfield units) to opacity and the other maps recorded intensity values to color. Both can be adjusted using the controls at the top of the Rendering tab. The graph at the top shows a histogram of the recorded intensity values in light gray and the current opacity transfer function as an overlaid curve in black. In that graph, beneath the black curve, is a depiction of the color transfer function. ![Cinematic](../gallery/16-volview-rendering.jpg)
 
-2. You may decide that the colormaps and/or transfer function aren't suitable for your data.  Click on the "Presets" bar to expand and show the available presets that offer alternative opacity and color transfer functions. ![Presets](../gallery/18-volview-presets.jpg)
-[***Watch the video!***](https://youtu.be/eyrGd-meg6I)
+   1. Begin by adjusting the opacity transfer function by a press-and-drag right/left on the top graph. ![Opacity](../gallery/17-volview-opacity-notes.jpg)
+   2. Then adjust the color transfer function by moving the blue dots on the colorbar beneath the graph. ![Color](../gallery/17-volview-colormap-notes.jpg)
 
-3. Next, the lighting can be controlled.  
-    1. Ambient lighting is the general brightness of the scene.  
-    2. Diffuse lighting controls how the light reflects off the data.  It is influenced by the position of the light relative to the orientation of the data's local surface.
-    3. Light-follows-camera can be enabled / disabled to create shadows that highlights details within the data.  When enabled, the light will be positioned in-line with the camera.   When disabled, the last position of the light stays fixed relative to the data, even if the camera is moved. With light-follows-camera enabled, here is a view when the light is following the camera: ![Default Lighting](../gallery/20-volview-lightfollowcamera1.jpg).  By moving the camera (and thereby the light) to the front of the data and then disabling light-follows-camera, the view should look light this: ![Light Setup](../gallery/20-volview-lightfollowcamera2.jpg).  Then moving back to the side view will show shadows that emphasize depth and details: ![Shadows](../gallery/20-volview-lightfollowcamera3.jpg).
+2. You may decide that the colormaps and/or transfer function aren't suitable for your data. Click on the "Presets" bar to expand and show the available presets that offer alternative opacity and color transfer functions. ![Presets](../gallery/18-volview-presets.jpg)
+   [**_Watch the video!_**](https://youtu.be/eyrGd-meg6I)
+
+3. Next, the lighting can be controlled.
+
+   1. Ambient lighting is the general brightness of the scene.
+   2. Diffuse lighting controls how the light reflects off the data. It is influenced by the position of the light relative to the orientation of the data's local surface.
+   3. Light-follows-camera can be enabled / disabled to create shadows that highlights details within the data. When enabled, the light will be positioned in-line with the camera. When disabled, the last position of the light stays fixed relative to the data, even if the camera is moved. With light-follows-camera enabled, here is a view when the light is following the camera: ![Default Lighting](../gallery/20-volview-lightfollowcamera1.jpg). By moving the camera (and thereby the light) to the front of the data and then disabling light-follows-camera, the view should look light this: ![Light Setup](../gallery/20-volview-lightfollowcamera2.jpg). Then moving back to the side view will show shadows that emphasize depth and details: ![Shadows](../gallery/20-volview-lightfollowcamera3.jpg).
 
 4. Advanced, you can also explore alternative cinematic rendering methods.
-    1. Standard
-    2. Hybrid
-    3. Ambient Occlusion
+   1. Standard
+   2. Hybrid
+   3. Ambient Occlusion

--- a/documentation/content/doc/state_files.md
+++ b/documentation/content/doc/state_files.md
@@ -1,18 +1,11 @@
-title: State Files
-----
+# State Files
 
-<style>
-table {
-  width: 100%;
-}
-</style>
-
-VolView state files are a great way to save your scene and data to either be used later, or for distributing to collaborators and other users. These files store all of the information you need to restore the state of VolView: your data, annotations, camera positions, background colors, colormaps, and more. 
+VolView state files are a great way to save your scene and data to either be used later, or for distributing to collaborators and other users. These files store all of the information you need to restore the state of VolView: your data, annotations, camera positions, background colors, colormaps, and more.
 
 State files can be saved by clicking on "Disk" icon in the top of the toolbar. This button will generate a `*.volview` file that can then be re-opened in VolView at any time.
 
-When saving VolView state, your data is saved along with the application state. This way, when you send a state file to a collaborator, they too can open the state file and load the previously saved data. However, this means that your state file will be as large as your dataset(s) and may contain patient identifying information.  Please follow your institutes HIPAA, IRB and other regulatory and confidentiality requirements.
+When saving VolView state, your data is saved along with the application state. This way, when you send a state file to a collaborator, they too can open the state file and load the previously saved data. However, this means that your state file will be as large as your dataset(s) and may contain patient identifying information. Please follow your institutes HIPAA, IRB and other regulatory and confidentiality requirements.
 
-State files are loaded by clicking on the "Folder" icon immediately below the save-state Disk icon.  This will bring up a file browser for you to select and load your state file.
+State files are loaded by clicking on the "Folder" icon immediately below the save-state Disk icon. This will bring up a file browser for you to select and load your state file.
 
-TIP: State files are a great way for developers to transfer data into / out of VolView for integration with other systems.  For example, they can be used to integrate VolView with access control systems, to streamline workflows, or to ingest results from AI systems.
+TIP: State files are a great way for developers to transfer data into / out of VolView for integration with other systems. For example, they can be used to integrate VolView with access control systems, to streamline workflows, or to ingest results from AI systems.

--- a/documentation/content/doc/toolbar.md
+++ b/documentation/content/doc/toolbar.md
@@ -1,12 +1,16 @@
-# title: Toolbar
+# Toolbar
 
 ## Layout
 
-Use the layout button to choose between window arrangements. As in all things, if you have a particular layout that you would like to see added, please make a feature request on our ["issue tracker"](https://github.com/Kitware/VolView/issues). ![Layout](../gallery/07-volview-layout-notes.jpg)
+Use the layout button to choose between window arrangements. As in all things, if you have a particular layout that you would like to see added, please make a feature request on our ["issue tracker"](https://github.com/Kitware/VolView/issues).
+
+![Layout](../gallery/07-volview-layout-notes.jpg)
 
 ## 2D View left mouse button
 
-Window / Level, Pan, Zoom, or Crosshairs: Select these options to control the function of the left mouse button in the 2D windows. ![Window-Level, Pan, Zoom, Crosshairs](../gallery/10-volview-wl-pan-zoom-notes.jpg)
+Window / Level, Pan, Zoom, or Crosshairs: Select these options to control the function of the left mouse button in the 2D windows.
+
+![Window-Level, Pan, Zoom, Crosshairs](../gallery/10-volview-wl-pan-zoom-notes.jpg)
 
 ## 2D Annotations
 
@@ -26,6 +30,8 @@ When the rectangle tool selected, the left mouse button is used to place and adj
 
 ## 3D Crop
 
-Select this tool to adjust the extent of data shown in the 3D rendering. In the 3D window you can pick and move the corner, edge, and side markers to make adjustments. In the 2D windows, grab and move the edges of the bounding box overlaid on the data. ![Crop](../gallery/13-volview-crop.jpg)
+Select this tool to adjust the extent of data shown in the 3D rendering. In the 3D window you can pick and move the corner, edge, and side markers to make adjustments. In the 2D windows, grab and move the edges of the bounding box overlaid on the data.
+
+![Crop](../gallery/13-volview-crop.jpg)
 
 [**_Watch the video!_**](https://youtu.be/Bj4ijh_VLUQ)

--- a/documentation/content/doc/welcome_screen.md
+++ b/documentation/content/doc/welcome_screen.md
@@ -1,23 +1,31 @@
-title: Welcome Screen
-----
+# Welcome Screen
 
-<style>
-table {
-  width: 100%;
-}
-</style>
+![welcome screen](../gallery/01-volview-welcome-notes.jpg)
 
-![](img:../gallery/01-volview-welcome-notes.jpg)
+## Tabs
 
-* **Tabs** organize the high-level functions.
-    * **Data** provides information on the Patient data and non-DICOM data that have been loaded. It also provides access to sample data.  The currently display image data is highlighted in blue.
-    * **Annotations** lists the ruler and other measures that have been made on the currently loaded data.
-    * **Rendering** provides the controls for the 3D cinematic volume rendering.
+### Data
 
-* **Sample Data** presents a variety of DICOM data that can be used to quickly explore the capabilities of VolView.  When you select a sample dataset, that data is downloaded from [http://data.kitware.com/](https://data.kitware.com/#collection/586fef9f8d777f05f44a5c86/folder/634713cf11dab81428208e1e).
+Information on the Patient data and non-DICOM data that have been loaded. The currently display image data is highlighted in blue.
 
-* **Load / Save State** icons are used to restore or create a local file that captures the current configuration of the application and its data.  This includes the layout, annotations, cinematic rendering settings, and all other options specified.  The local file is in json format, so it provides a basis for integrating VolView with other applications and workflows.
+**Sample Data** presents a variety of DICOM data that can be used to quickly explore the capabilities of VolView. When you select a sample dataset, that data is downloaded from [http://data.kitware.com/](https://data.kitware.com/#collection/586fef9f8d777f05f44a5c86/folder/634713cf11dab81428208e1e).
 
-* **Notifications and Settings** provide information and error messages and allow you to toggle between a dark or light theme. The number of recently posted notifications will appear on top of the notification icon.
+### Annotations
 
-* **Central Window** is used to receive DICOM data via drag-and-drop (receives files, folders, or zip files), or you can click within this window to bring up a file browser.
+Lists the ruler and other measures that have been made on the currently loaded data.
+
+### Rendering
+
+Controls for the 3D cinematic volume rendering.
+
+## Load / Save State
+
+Restore or create a local file that captures the current configuration of the application and its data. This includes the layout, annotations, cinematic rendering settings, and all other options specified. The local file is in json format, so it provides a basis for integrating VolView with other applications and workflows.
+
+## Notifications and Settings
+
+Information and error messages collect here. The number of recently posted notifications will appear on top of the notification icon. Settings allow you to toggle between a dark or light theme.
+
+## Central Window
+
+Drag-and-drop DICOM and image data here. Receives files, folders, or zip files. Or you can click within this window to bring up a file browser.


### PR DESCRIPTION
Ditches the nice thin title font for standard markdown simplicity.  Fixes title prefix.

Adds DICOMWeb docs

Fixes overflow on URL parameters.