### PR TITLE
refactor(ToolButton): improve API and support menus

### DIFF
--- a/src/components/PaintControls.vue
+++ b/src/components/PaintControls.vue
@@ -77,6 +77,7 @@
             hide-mode-switch
             hide-sliders
             show-swatches
+            elevation="0"
             :swatches="swatches"
             :model-value="brushColor"
             @update:model-value="setBrushColor"

--- a/src/components/ToolButton.vue
+++ b/src/components/ToolButton.vue
@@ -1,36 +1,50 @@
 <template>
-  <v-btn
-    variant="text"
-    :rounded="0"
-    dark
-    :height="sizeV"
-    :width="sizeV"
-    :min-width="sizeV"
-    :max-width="sizeV"
-    :class="classV"
-    v-bind="$attrs"
+  <v-menu
+    location="end"
+    :close-on-content-click="false"
+    :disabled="!!$slots.menu"
+    v-bind="menu"
   >
-    <v-icon :size="iconSize">{{ icon }}</v-icon>
-    <v-tooltip
-      :location="tooltipLocation"
-      activator="parent"
-      transition="slide-x-transition"
-    >
-      <span>{{ name }}</span>
-    </v-tooltip>
-    <slot />
-  </v-btn>
+    <template #activator="{ props: menuProps }">
+      <v-tooltip
+        location="right"
+        transition="slide-x-transition"
+        v-bind="tooltip"
+      >
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            variant="text"
+            :rounded="0"
+            dark
+            :height="sizeV"
+            :width="sizeV"
+            :min-width="sizeV"
+            :max-width="sizeV"
+            v-bind="mergeProps(menuProps, tooltipProps, button, $attrs)"
+          >
+            <v-icon :size="iconSize">{{ icon }}</v-icon>
+            <slot />
+          </v-btn>
+        </template>
+        <span>{{ name }}</span>
+      </v-tooltip>
+    </template>
+    <slot name="menu" />
+  </v-menu>
 </template>
 
 <script>
+import { mergeProps } from 'vue';
+
 export default {
   name: 'ToolButton',
   props: {
     icon: { type: String, required: true },
     name: { type: String, required: true },
     size: { type: [Number, String], default: 40 },
-    buttonClass: [String, Array, Object],
-    tooltipLocation: { type: String, default: 'right' },
+    button: { type: Object, default: () => ({}) },
+    tooltip: { type: Object, default: () => ({}) },
+    menu: { type: Object, default: () => ({}) },
   },
 
   computed: {
@@ -40,21 +54,10 @@ export default {
     iconSize() {
       return Math.floor(0.6 * this.sizeV);
     },
-    classV() {
-      const classSpec = this.buttonClass;
-      if (typeof classSpec === 'string') {
-        return classSpec;
-      }
-      if (Array.isArray(classSpec)) {
-        return classSpec.join(' ');
-      }
-      if (classSpec && Object.keys(classSpec).length) {
-        return Object.keys(this.buttonClass)
-          .filter((key) => this.buttonClass[key])
-          .join(' ');
-      }
-      return '';
-    },
+  },
+
+  methods: {
+    mergeProps,
   },
 };
 </script>

--- a/src/components/ToolStrip.vue
+++ b/src/components/ToolStrip.vue
@@ -13,7 +13,7 @@
         size="40"
         icon="mdi-circle-half-full"
         name="Window & Level"
-        :buttonClass="['tool-btn', active ? 'tool-btn-selected' : '']"
+        :button="{ class: ['tool-btn', active ? 'tool-btn-selected' : ''] }"
         :disabled="noCurrentImage"
         @click="toggle"
       />
@@ -23,7 +23,7 @@
         size="40"
         icon="mdi-cursor-move"
         name="Pan"
-        :buttonClass="['tool-btn', active ? 'tool-btn-selected' : '']"
+        :button="{ class: ['tool-btn', active ? 'tool-btn-selected' : ''] }"
         :disabled="noCurrentImage"
         @click="toggle"
       />
@@ -33,7 +33,7 @@
         size="40"
         icon="mdi-magnify-plus-outline"
         name="Zoom"
-        :buttonClass="['tool-btn', active ? 'tool-btn-selected' : '']"
+        :button="{ class: ['tool-btn', active ? 'tool-btn-selected' : ''] }"
         :disabled="noCurrentImage"
         @click="toggle"
       />
@@ -46,38 +46,28 @@
         size="40"
         icon="mdi-crosshairs"
         name="Crosshairs"
-        :buttonClass="['tool-btn', active ? 'tool-btn-selected' : '']"
+        :button="{ class: ['tool-btn', active ? 'tool-btn-selected' : ''] }"
         :disabled="noCurrentImage"
         @click="toggle"
       />
     </groupable-item>
     <div class="my-1 tool-separator" />
     <groupable-item v-slot:default="{ active, toggle }" :value="Tools.Paint">
-      <v-menu
-        v-model="paintMenu"
-        location="end"
-        :close-on-content-click="false"
-        :disabled="!active"
+      <tool-button
+        size="40"
+        icon="mdi-brush"
+        name="Paint"
+        :button="{ class: ['tool-btn', active ? 'tool-btn-selected' : ''] }"
+        :disabled="noCurrentImage"
+        @click.stop="toggle"
       >
-        <template v-slot:activator="{ props }">
-          <div>
-            <tool-button
-              size="40"
-              icon="mdi-brush"
-              name="Paint"
-              :buttonClass="['tool-btn', active ? 'tool-btn-selected' : '']"
-              :disabled="noCurrentImage"
-              @click.stop="toggle"
-              v-bind="props"
-            >
-              <v-icon v-if="active" class="menu-more" size="18">
-                mdi-menu-right
-              </v-icon>
-            </tool-button>
-          </div>
+        <v-icon v-if="active" class="menu-more" size="18">
+          mdi-menu-right
+        </v-icon>
+        <template #menu>
+          <paint-controls />
         </template>
-        <paint-controls />
-      </v-menu>
+      </tool-button>
     </groupable-item>
     <groupable-item
       v-slot:default="{ active, toggle }"
@@ -87,7 +77,7 @@
         size="40"
         icon="mdi-vector-square"
         name="Rectangle"
-        :buttonClass="['tool-btn', active ? 'tool-btn-selected' : '']"
+        :button="{ class: ['tool-btn', active ? 'tool-btn-selected' : ''] }"
         :disabled="noCurrentImage"
         @click="toggle"
       />
@@ -97,46 +87,35 @@
         size="40"
         icon="mdi-ruler"
         name="Ruler"
-        :buttonClass="['tool-btn', active ? 'tool-btn-selected' : '']"
+        :button="{ class: ['tool-btn', active ? 'tool-btn-selected' : ''] }"
         :disabled="noCurrentImage"
         @click="toggle"
       />
     </groupable-item>
     <div class="my-1 tool-separator" />
     <groupable-item v-slot:default="{ active, toggle }" :value="Tools.Crop">
-      <v-menu
-        v-model="cropMenu"
-        location="end"
-        open-on-hover
-        close-on-content-click
+      <tool-button
+        size="40"
+        icon="mdi-crop"
+        name="Crop"
+        :tooltip="{ location: 'bottom', transition: 'slide-y-transition' }"
+        :button="{ class: ['tool-btn', active ? 'tool-btn-selected' : ''] }"
+        :disabled="noCurrentImage"
+        @click.stop="toggle"
       >
-        <template v-slot:activator="{ props }">
-          <div>
-            <tool-button
-              size="40"
-              icon="mdi-crop"
-              name="Crop"
-              tooltipLocation="bottom"
-              :buttonClass="['tool-btn', active ? 'tool-btn-selected' : '']"
-              :disabled="noCurrentImage"
-              @click.stop="toggle"
-              v-bind="props"
-            >
-              <v-icon v-if="active" class="menu-more" size="18">
-                mdi-menu-right
-              </v-icon>
-            </tool-button>
-          </div>
+        <v-icon v-if="active" class="menu-more" size="18">
+          mdi-menu-right
+        </v-icon>
+        <template #menu>
+          <crop-controls />
         </template>
-        <crop-controls />
-      </v-menu>
+      </tool-button>
     </groupable-item>
   </item-group>
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref } from 'vue';
-import { onKeyDown } from '@vueuse/core';
+import { computed, defineComponent } from 'vue';
 import { Tools } from '@/src/store/tools/types';
 import ToolButton from './ToolButton.vue';
 import ItemGroup from './ItemGroup.vue';
@@ -161,21 +140,11 @@ export default defineComponent({
     const noCurrentImage = computed(() => !dataStore.primaryDataset);
     const currentTool = computed(() => toolStore.currentTool);
 
-    const paintMenu = ref(false);
-    const cropMenu = ref(false);
-
-    onKeyDown('Escape', () => {
-      paintMenu.value = false;
-      cropMenu.value = false;
-    });
-
     return {
       currentTool,
       setCurrentTool: toolStore.setCurrentTool,
       noCurrentImage,
       Tools,
-      paintMenu,
-      cropMenu,
     };
   },
 });
@@ -190,7 +159,7 @@ export default defineComponent({
 <style scoped>
 .menu-more {
   position: absolute;
-  right: -10%;
+  right: -12%;
 }
 
 .tool-separator {


### PR DESCRIPTION
Adds an easier-to-use API and menu support to cut down on duplicate markup. Additonally makes menu more discoverable by popping up on first click..

FYI @PaulHax this is going into the vue3 branch. I want to keep this separate since it's an added internal feature.