### PR TITLE
AboutBox: Add link to discourse category for community support

### DIFF
--- a/src/components/AboutBox.vue
+++ b/src/components/AboutBox.vue
@@ -33,6 +33,7 @@
 
       <ul>
         <li>Fast: Drag-and-drop DICOM files for quick viewing</li>
+        <li>Flexible: Designed to be easily integrated into existing systems</li>
         <li>
           Beautiful: Cinematic volume rendering to generate high-quality 3D
           visualizations
@@ -87,6 +88,19 @@
             href="https://github.com/Kitware/VolView"
           >
             https://github.com/Kitware/VolView
+          </a>
+        </li>
+      </ul>
+      <br />
+      VolView community support forum:
+      <ul>
+        <li>
+          <a
+            rel="noopener noreferrer"
+            target="_blank"
+            href="https://discourse.vtk.org/c/web/volview/14"
+          >
+            https://discourse.vtk.org/c/web/volview/14
           </a>
         </li>
       </ul>

--- a/src/components/AboutBox.vue
+++ b/src/components/AboutBox.vue
@@ -33,7 +33,9 @@
 
       <ul>
         <li>Fast: Drag-and-drop DICOM files for quick viewing</li>
-        <li>Flexible: Designed to be easily integrated into existing systems</li>
+        <li>
+          Flexible: Designed to be easily integrated into existing systems
+        </li>
         <li>
           Beautiful: Cinematic volume rendering to generate high-quality 3D
           visualizations


### PR DESCRIPTION
Add a link in the AboutBox to the VolView community support forum.

Community Support is available in the VolView subcategory in the VTK/Web discourse forum.
* https://discourse.vtk.org/c/web/volview/14
