### PR TITLE
Fixes for tool widget manager life-cycle and SVG tool resize update

### DIFF
--- a/src/components/VtkTwoView.vue
+++ b/src/components/VtkTwoView.vue
@@ -32,7 +32,7 @@
       <div class="vtk-sub-container">
         <div class="vtk-view" ref="vtkContainerRef" />
       </div>
-      <div class="overlay-no-events tool-layer">
+      <div class="overlay-no-events tool-layer" ref="toolContainer">
         <pan-tool :view-id="viewID" />
         <zoom-tool :view-id="viewID" />
         <slice-scroll-tool :view-id="viewID" />
@@ -212,7 +212,7 @@ import useViewSliceStore, {
   defaultSliceConfig,
 } from '../store/view-configs/slicing';
 import CropTool from './tools/CropTool.vue';
-import { VTKTwoViewWidgetManager } from '../constants';
+import { ToolContainer, VTKTwoViewWidgetManager } from '../constants';
 import { useProxyManager } from '../composables/proxyManager';
 import { getShiftedOpacityFromPreset } from '../utils/vtk-helpers';
 import { useLayersStore } from '../store/datasets-layers';
@@ -420,6 +420,10 @@ export default defineComponent({
     // --- resizing --- //
 
     useResizeObserver(vtkContainerRef, () => viewProxy.value.resize());
+
+    // Used by SVG tool widgets for resizeCallback
+    const toolContainer = ref<HTMLElement>();
+    provide(ToolContainer, toolContainer);
 
     // --- widget manager --- //
 
@@ -726,6 +730,7 @@ export default defineComponent({
 
     return {
       vtkContainerRef,
+      toolContainer,
       viewID,
       viewProxy,
       viewAxis,

--- a/src/components/VtkTwoView.vue
+++ b/src/components/VtkTwoView.vue
@@ -32,7 +32,7 @@
       <div class="vtk-sub-container">
         <div class="vtk-view" ref="vtkContainerRef" />
       </div>
-      <div v-if="viewProxyMounted" class="overlay-no-events tool-layer">
+      <div class="overlay-no-events tool-layer">
         <pan-tool :view-id="viewID" />
         <zoom-tool :view-id="viewID" />
         <slice-scroll-tool :view-id="viewID" />
@@ -206,11 +206,7 @@ import { usePersistCameraConfig } from '../composables/usePersistCameraConfig';
 import CrosshairsTool from './tools/CrosshairsTool.vue';
 import { LPSAxisDir } from '../types/lps';
 import { ViewProxyType } from '../core/proxies';
-import {
-  useViewProxy,
-  useViewProxyMounted,
-  useViewProxyUnmounted,
-} from '../composables/useViewProxy';
+import { useViewProxy } from '../composables/useViewProxy';
 import { useWidgetManager } from '../composables/useWidgetManager';
 import useViewSliceStore, {
   defaultSliceConfig,
@@ -379,18 +375,6 @@ export default defineComponent({
 
     onBeforeUnmount(() => {
       setViewProxyContainer(null);
-    });
-
-    // delays mounting of vtkWidgets components until the view proxy has a container
-    // and vtkWidgetManager gets linked with view proxy
-    const viewProxyMounted = ref(false);
-
-    useViewProxyMounted(viewProxy, () => {
-      viewProxyMounted.value = true;
-    });
-
-    useViewProxyUnmounted(viewProxy, () => {
-      viewProxyMounted.value = false;
     });
 
     // --- Slicing setup --- //
@@ -761,7 +745,6 @@ export default defineComponent({
         resizeToFit.value = true;
       },
       hover,
-      viewProxyMounted,
     };
   },
 });

--- a/src/components/tools/crop/Crop3D.vue
+++ b/src/components/tools/crop/Crop3D.vue
@@ -19,11 +19,11 @@ import {
   defineComponent,
   inject,
   onBeforeUnmount,
-  onMounted,
   ref,
   toRefs,
   watch,
 } from 'vue';
+import { useViewProxyMounted } from '@/src/composables/useViewProxy';
 
 function isValidCroppingPlanes(planes: LPSCroppingPlanes) {
   return (
@@ -93,7 +93,7 @@ export default defineComponent({
       }
     });
 
-    onMounted(() => {
+    useViewProxyMounted(viewProxy, () => {
       if (widgetManager.value) {
         widget.value = widgetManager.value.addWidget(
           factory

--- a/src/components/tools/crosshairs/CrosshairSVG2D.vue
+++ b/src/components/tools/crosshairs/CrosshairSVG2D.vue
@@ -1,5 +1,5 @@
 <template>
-  <g ref="containerEl">
+  <g>
     <line
       v-if="x != null && y != null"
       :x1="x"
@@ -42,6 +42,7 @@
 <script lang="ts">
 import { useResizeObserver } from '@/src/composables/useResizeObserver';
 import { useVTKCallback } from '@/src/composables/useVTKCallback';
+import { ToolContainer } from '@/src/constants';
 import { useViewStore } from '@/src/store/views';
 import { worldToSVG } from '@/src/utils/vtk-helpers';
 import vtkLPSView2DProxy from '@/src/vtk/LPSView2DProxy';
@@ -54,6 +55,7 @@ import {
   ref,
   watchEffect,
   computed,
+  inject,
 } from 'vue';
 
 type SVGPoint = {
@@ -102,7 +104,7 @@ export default defineComponent({
 
     // --- resize --- //
 
-    const containerEl = ref<Element | null>(null);
+    const containerEl = inject(ToolContainer)!;
 
     useResizeObserver(containerEl, () => {
       updatePoints();
@@ -112,7 +114,6 @@ export default defineComponent({
       devicePixelRatio,
       x: computed(() => position2D.value?.x),
       y: computed(() => position2D.value?.y),
-      containerEl,
     };
   },
 });

--- a/src/components/tools/rectangle/RectangleSVG2D.vue
+++ b/src/components/tools/rectangle/RectangleSVG2D.vue
@@ -1,5 +1,5 @@
 <template>
-  <g ref="containerEl">
+  <g>
     <rect
       :x="rectangle.x"
       :y="rectangle.y"
@@ -34,6 +34,7 @@
 <script lang="ts">
 import { useResizeObserver } from '@/src/composables/useResizeObserver';
 import { useVTKCallback } from '@/src/composables/useVTKCallback';
+import { ToolContainer } from '@/src/constants';
 import { useViewStore } from '@/src/store/views';
 import { worldToSVG } from '@/src/utils/vtk-helpers';
 import vtkLPSView2DProxy from '@/src/vtk/LPSView2DProxy';
@@ -46,6 +47,7 @@ import {
   unref,
   ref,
   watch,
+  inject,
 } from 'vue';
 
 type SVGPoint = {
@@ -133,7 +135,7 @@ export default defineComponent({
 
     // --- resize --- //
 
-    const containerEl = ref<Element | null>(null);
+    const containerEl = inject(ToolContainer)!;
 
     useResizeObserver(containerEl, () => {
       updatePoints();
@@ -144,7 +146,6 @@ export default defineComponent({
       first: firstPoint,
       second: secondPoint,
       rectangle,
-      containerEl,
     };
   },
 });

--- a/src/components/tools/ruler/RulerSVG2D.vue
+++ b/src/components/tools/ruler/RulerSVG2D.vue
@@ -1,5 +1,5 @@
 <template>
-  <g ref="containerEl">
+  <g>
     <line
       v-if="first && second"
       :x1="first.x"
@@ -50,6 +50,7 @@
 <script lang="ts">
 import { useResizeObserver } from '@/src/composables/useResizeObserver';
 import { useVTKCallback } from '@/src/composables/useVTKCallback';
+import { ToolContainer } from '@/src/constants';
 import { useViewStore } from '@/src/store/views';
 import { worldToSVG } from '@/src/utils/vtk-helpers';
 import vtkLPSView2DProxy from '@/src/vtk/LPSView2DProxy';
@@ -62,6 +63,7 @@ import {
   unref,
   ref,
   watch,
+  inject,
 } from 'vue';
 
 type SVGPoint = {
@@ -159,7 +161,7 @@ export default defineComponent({
 
     // --- resize --- //
 
-    const containerEl = ref<Element | null>(null);
+    const containerEl = inject(ToolContainer)!;
 
     useResizeObserver(containerEl, () => {
       updatePoints();
@@ -173,7 +175,6 @@ export default defineComponent({
       first: firstPoint,
       second: secondPoint,
       rulerLength: computed(() => length?.value?.toFixed(2) ?? ''),
-      containerEl,
     };
   },
 });

--- a/src/composables/useViewProxy.ts
+++ b/src/composables/useViewProxy.ts
@@ -48,15 +48,27 @@ function onViewProxyModified<T extends vtkViewProxy = vtkViewProxy>(
   onModified(callback);
 }
 
+function useMountedViewProxy<T extends vtkViewProxy = vtkViewProxy>(
+  viewProxy: MaybeRef<T>
+) {
+  const mounted = ref(false);
+
+  const updateMounted = () => {
+    mounted.value = !!unref(viewProxy).getContainer();
+  };
+
+  updateMounted();
+
+  onViewProxyModified(viewProxy, updateMounted);
+
+  return mounted;
+}
+
 export function useViewProxyMounted<T extends vtkViewProxy = vtkViewProxy>(
   viewProxy: MaybeRef<T>,
   callback: () => void
 ) {
-  const mounted = ref(false);
-
-  onViewProxyModified(viewProxy, () => {
-    mounted.value = !!unref(viewProxy).getContainer();
-  });
+  const mounted = useMountedViewProxy(viewProxy);
 
   watch(
     mounted,
@@ -71,11 +83,7 @@ export function useViewProxyUnmounted<T extends vtkViewProxy = vtkViewProxy>(
   viewProxy: MaybeRef<T>,
   callback: () => void
 ) {
-  const mounted = ref(false);
-
-  onViewProxyModified(viewProxy, () => {
-    mounted.value = !!unref(viewProxy).getContainer();
-  });
+  const mounted = useMountedViewProxy(viewProxy);
 
   watch(
     mounted,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,5 @@
 import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
-import { ComputedRef, InjectionKey } from 'vue';
+import { ComputedRef, InjectionKey, Ref } from 'vue';
 
 export const EPSILON = 10e-6;
 export const NOOP = () => {};
@@ -23,6 +23,12 @@ export const VTKTwoViewWidgetManager: InjectionKey<
 export const VTKThreeViewWidgetManager: InjectionKey<
   ComputedRef<vtkWidgetManager>
 > = Symbol('VTKThreeViewWidgetManager');
+
+/**
+ * Retrieves the parent tool HTML element.
+ */
+export const ToolContainer: InjectionKey<Ref<HTMLElement>> =
+  Symbol('ToolContainer');
 
 export const DataTypes = {
   Image: 'Image',


### PR DESCRIPTION
Crop3D: Avoids calling widgetManger.addWidget before widgetManager is linked to viewProxy

Reverts conditional rendering of 2D tools on useViewProxyMounted.  Applies initialization fix to useViewProxy to avoid adding a widget to widgetManager before linking with viewProxy.

Fixes resize update for SVG widgets by calling ResizeObserver  with tool container DIV rather than SVG group element (which did not trigger ResizeObserver callback.) 

fixes #343 

