### PR TITLE
chore(vite): dev server on port 8080

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -126,6 +126,9 @@ export default defineConfig({
         })
       : ({} as Plugin),
   ],
+  server: {
+    port: 8080,
+  },
   test: {
     environment: 'jsdom',
     // canvas support. See: https://github.com/vitest-dev/vitest/issues/740


### PR DESCRIPTION
We will stick with 8080, as was the case pre-vite migration.