### PR TITLE
Better chunking to reduce asset sizes

### DIFF
--- a/src/io/amazonS3.ts
+++ b/src/io/amazonS3.ts
@@ -1,5 +1,6 @@
-import { S3Client, ListObjectsV2Command } from '@aws-sdk/client-s3';
 import { URL } from 'whatwg-url';
+
+const importAwsSdk = () => import('@/src/lazy/lazyAwsSdk');
 
 /**
  * Detects `s3://` uri.
@@ -19,6 +20,8 @@ async function fetchObjectsWithPagination(
   prefix: string,
   onObjectAvailable: ObjectAvailableCallback = () => {}
 ) {
+  const { S3Client, ListObjectsV2Command } = await importAwsSdk();
+
   const client = new S3Client({
     region: 'us-east-1',
     // workaround for sdk's inability to specify anonymous credentials

--- a/src/io/state-file/index.ts
+++ b/src/io/state-file/index.ts
@@ -1,4 +1,3 @@
-import JSZip from 'jszip';
 import { useDatasetStore } from '@/src/store/datasets';
 import { useLabelmapStore } from '@/src/store/datasets-labelmaps';
 import { useLayersStore } from '@/src/store/datasets-layers';
@@ -11,6 +10,8 @@ import { Manifest } from './schema';
 import { retypeFile } from '../io';
 import { ARCHIVE_FILE_TYPES } from '../mimeTypes';
 
+const importJSZip = () => import('@/src/lazy/lazyJSZip');
+
 export const MANIFEST = 'manifest.json';
 export const MANIFEST_VERSION = '2.1.0';
 
@@ -21,6 +22,7 @@ export async function serialize() {
   const toolStore = useToolStore();
   const layersStore = useLayersStore();
 
+  const { JSZip } = await importJSZip();
   const zip = new JSZip();
   const manifest: Manifest = {
     version: MANIFEST_VERSION,
@@ -67,6 +69,7 @@ export async function serialize() {
 export async function isStateFile(file: File) {
   const typedFile = await retypeFile(file);
   if (ARCHIVE_FILE_TYPES.has(typedFile.type)) {
+    const { JSZip } = await importJSZip();
     const zip = await JSZip.loadAsync(typedFile);
 
     return zip.file(MANIFEST) !== null;

--- a/src/io/state-file/schema.ts
+++ b/src/io/state-file/schema.ts
@@ -1,4 +1,4 @@
-import JSZip from 'jszip';
+import type JSZip from 'jszip';
 import { z } from 'zod';
 import type { Vector3 } from '@kitware/vtk.js/types';
 import vtkPiecewiseFunctionProxy, {

--- a/src/io/zip.ts
+++ b/src/io/zip.ts
@@ -1,8 +1,10 @@
-import JSZip from 'jszip';
 import { basename, dirname } from '@/src/utils/path';
 import { FileEntry } from './types';
 
+const importJSZip = () => import('@/src/lazy/lazyJSZip');
+
 export async function extractFilesFromZip(zipFile: File): Promise<FileEntry[]> {
+  const { JSZip } = await importJSZip();
   const zip = await JSZip.loadAsync(zipFile);
   const promises: Promise<File>[] = [];
   const paths: string[] = [];

--- a/src/lazy/index.ts
+++ b/src/lazy/index.ts
@@ -1,0 +1,25 @@
+import { config as configAwsSdk } from './lazyAwsSdk';
+import { config as configJSZip } from './lazyJSZip';
+
+interface Config {
+  autoChunk: Array<RegExp>;
+}
+
+const configs = [configAwsSdk, configJSZip].filter(
+  (config): config is Config => {
+    const autoChunk = config?.autoChunk;
+    if (!Array.isArray(autoChunk)) return false;
+    return autoChunk.every((pattern) => pattern instanceof RegExp);
+  }
+);
+
+/**
+ * Determines if we should let rollup handle chunking on a given ID.
+ *
+ * Only runs on node_modules. See vite.config.ts for more info.
+ */
+export const shouldAutoChunk = (id: string) => {
+  return configs.some((config) => {
+    return config.autoChunk.some((pattern) => pattern.test(id));
+  });
+};

--- a/src/lazy/lazyAwsSdk.ts
+++ b/src/lazy/lazyAwsSdk.ts
@@ -1,0 +1,4 @@
+export { S3Client, ListObjectsV2Command } from '@aws-sdk/client-s3';
+export const config = {
+  autoChunk: [/@aws-(sdk|crypto)/],
+};

--- a/src/lazy/lazyJSZip.ts
+++ b/src/lazy/lazyJSZip.ts
@@ -1,0 +1,4 @@
+export { default as JSZip } from 'jszip';
+export const config = {
+  autoChunk: [/jszip/],
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ import { sentryVitePlugin } from '@sentry/vite-plugin';
 import replace from '@rollup/plugin-replace';
 
 import pkgLock from './package-lock.json';
+import { shouldAutoChunk } from './src/lazy';
 
 function resolve(...args) {
   return normalizePath(resolvePath(...args));
@@ -43,9 +44,18 @@ export default defineConfig({
             return 'vuetify';
           }
           if (id.includes('vtk.js')) {
+            if (id.includes('OpenGL')) {
+              return 'vtk.js-opengl';
+            }
             return 'vtk.js';
           }
           if (id.includes('node_modules')) {
+            if (shouldAutoChunk(id)) {
+              return undefined;
+            }
+            if (id.includes('whatwg-url')) {
+              return 'whatwg-url';
+            }
             return 'vendor';
           }
           return undefined;


### PR DESCRIPTION
- Splits out some dependencies from the vendor chunk
- moves JSZip and AWS SDK to dynamic imports to reduce initial download size

Before:
```
✓ 1873 modules transformed.
dist/index.html                                1.05 kB │ gzip:   0.51 kB
dist/assets/KitwareHeadAndNeck-6fe4377e.jpg   27.03 kB
dist/assets/pipeline.worker-9f119a72.js       42.50 kB
dist/assets/async.writer.worker-42a67950.js  694.75 kB
dist/assets/async.reader.worker-f0ea3ad1.js  745.69 kB
dist/assets/vendor-4522082c.css               12.87 kB │ gzip:   2.06 kB
dist/assets/index-1e904cb7.css                23.05 kB │ gzip:   3.73 kB
dist/assets/vuetify-e8664618.css             359.80 kB │ gzip:  44.84 kB
dist/assets/vuetify-c3068a37.js              208.00 kB │ gzip:  66.06 kB │ map:   832.09 kB
dist/assets/index-3918bbaa.js                295.06 kB │ gzip: 103.59 kB │ map: 1,010.02 kB
dist/assets/vtk.js-053a3c9f.js               819.51 kB │ gzip: 210.78 kB │ map: 3,026.10 kB
dist/assets/vendor-c87afde9.js               923.37 kB │ gzip: 273.60 kB │ map: 3,880.06 kB
```

After:

```
✓ 1875 modules transformed.
dist/index.html                                1.20 kB │ gzip:   0.54 kB
dist/assets/KitwareHeadAndNeck-6fe4377e.jpg   27.03 kB
dist/assets/pipeline.worker-9f119a72.js       42.50 kB
dist/assets/async.writer.worker-42a67950.js  694.75 kB
dist/assets/async.reader.worker-f0ea3ad1.js  745.69 kB
dist/assets/vendor-4522082c.css               12.87 kB │ gzip:   2.06 kB
dist/assets/index-1e904cb7.css                23.05 kB │ gzip:   3.73 kB
dist/assets/vuetify-e8664618.css             359.80 kB │ gzip:  44.84 kB
dist/assets/lazyJSZip-12894b61.js             97.10 kB │ gzip:  30.04 kB │ map:   225.74 kB
dist/assets/lazyAwsSdk-b380c68e.js           176.28 kB │ gzip:  46.58 kB │ map: 1,034.05 kB
dist/assets/vuetify-a9c1303b.js              208.00 kB │ gzip:  66.06 kB │ map:   832.09 kB
dist/assets/whatwg-url-b9537523.js           244.18 kB │ gzip:  70.41 kB │ map:   233.88 kB
dist/assets/index-7a6822ef.js                295.69 kB │ gzip: 103.85 kB │ map:   988.99 kB
dist/assets/vtk.js-opengl-ebfe7419.js        312.07 kB │ gzip:  72.43 kB │ map:   889.49 kB
dist/assets/vendor-feed69ad.js               404.05 kB │ gzip: 126.41 kB │ map: 2,374.15 kB
dist/assets/vtk.js-350e3cce.js               508.24 kB │ gzip: 136.44 kB │ map: 2,132.17 kB
```