### PR TITLE
DICOMWeb fixes

### DIFF
--- a/src/components/DataBrowser.vue
+++ b/src/components/DataBrowser.vue
@@ -45,10 +45,7 @@ export default defineComponent({
           .length > 0
     );
 
-    const panels = ref<string[]>([
-      SAMPLE_DATA_KEY,
-      ...(dicomWeb.isConfigured ? [DICOM_WEB_KEY] : []),
-    ]);
+    const panels = ref<string[]>([SAMPLE_DATA_KEY, DICOM_WEB_KEY]);
 
     watch(
       [hasAnonymousImages, patients] as const,

--- a/src/components/dicom-web/DicomWebSettings.vue
+++ b/src/components/dicom-web/DicomWebSettings.vue
@@ -1,20 +1,13 @@
 <script lang="ts">
-import { defineComponent, onMounted, onUnmounted, ref } from 'vue';
+import { defineComponent, onUnmounted } from 'vue';
 import { useDicomWebStore } from '../../store/dicom-web/dicom-web-store';
 
 export default defineComponent({
   setup() {
     const dicomWeb = useDicomWebStore();
 
-    // If host changed while mounted, fetch metadata
-    const hostAtStart = ref<typeof dicomWeb.host>();
-    onMounted(() => {
-      hostAtStart.value = dicomWeb.host;
-    });
     onUnmounted(() => {
-      // Re-fetch if address changed or an error message exists
-      if (hostAtStart.value !== dicomWeb.host || dicomWeb.message)
-        dicomWeb.fetchInitialDicoms();
+      dicomWeb.fetchDicomsOnce();
     });
 
     return {
@@ -34,7 +27,7 @@ export default defineComponent({
       clearable
     />
     <v-text-field
-      v-model="dicomWeb.host"
+      v-model="dicomWeb.savedHost"
       class="server-param"
       label="Host Address"
       clearable

--- a/src/components/dicom-web/PatientList.vue
+++ b/src/components/dicom-web/PatientList.vue
@@ -13,7 +13,7 @@ export default defineComponent({
   setup() {
     const dicomWebStore = useDicomWebStore();
     const dicomWebMeta = useDicomMetaStore();
-    dicomWebStore.fetchInitialDicomsOnce();
+    dicomWebStore.fetchDicomsOnce();
 
     const patients = computed(() =>
       Object.values(dicomWebMeta.patientInfo)

--- a/src/components/dicom-web/StudyVolumeDicomWeb.vue
+++ b/src/components/dicom-web/StudyVolumeDicomWeb.vue
@@ -151,7 +151,7 @@ export default defineComponent({
                           color="white"
                           :indeterminate="
                             volume.progress.percent === 0 &&
-                            volume.progress.state !== 'Done'
+                            volume.progress.state === 'Pending'
                           "
                           :model-value="volume.progress.percent"
                         >

--- a/src/store/dicom-web/dicom-web-store.ts
+++ b/src/store/dicom-web/dicom-web-store.ts
@@ -217,7 +217,7 @@ export const useDicomWebStore = defineStore('dicom-web', () => {
   const fetchError = ref<undefined | unknown>(undefined);
   // DICOMWeb DataBrowser components automatically expands panels if true
   const linkedToStudyOrSeries = ref(false);
-  const fetchInitialDicoms = async () => {
+  const fetchDicoms = async () => {
     fetchDicomsProgress.value = 'Pending';
     fetchError.value = undefined;
     linkedToStudyOrSeries.value = false;
@@ -262,13 +262,6 @@ export const useDicomWebStore = defineStore('dicom-web', () => {
     fetchDicomsProgress.value = 'Done';
   };
 
-  // Safe to call in components' setup()
-  const fetchInitialDicomsOnce = () => {
-    if (fetchDicomsProgress.value === 'Idle') {
-      fetchInitialDicoms();
-    }
-  };
-
   const message = computed(() => {
     if (fetchError.value)
       return `Error fetching DICOMWeb data: ${fetchError.value}`;
@@ -282,6 +275,15 @@ export const useDicomWebStore = defineStore('dicom-web', () => {
 
     return '';
   });
+
+  // Safe to call in components' setup()
+  let lastFetchedHostUrl: string | null = '';
+  const fetchDicomsOnce = () => {
+    if (lastFetchedHostUrl !== host.value || message.value) {
+      lastFetchedHostUrl = host.value;
+      fetchDicoms();
+    }
+  };
 
   const loadedDicoms = useDICOMStore();
   loadedDicoms.$onAction(({ name, args, after }) => {
@@ -303,13 +305,13 @@ export const useDicomWebStore = defineStore('dicom-web', () => {
 
   return {
     host,
+    savedHost,
     isConfigured,
     hostName,
     message,
     volumes,
     linkedToStudyOrSeries,
-    fetchInitialDicoms,
-    fetchInitialDicomsOnce,
+    fetchDicomsOnce,
     fetchPatientMeta,
     fetchVolumesMeta,
     fetchVolumeThumbnail,


### PR DESCRIPTION
* Stops unending spinner on volume thumbnail if error downloading volume
* Editing the host in the settings panel now saves the host to localStorage.
* Editing the host in the settings panel fetched all the studies *twice* if host started not configured.
* DICOMWeb panel now expands when host is configured from settings.