### PR TITLE
feat(polygon): add enter and double click to finish shortcuts

### DIFF
--- a/documentation/content/doc/toolbar.md
+++ b/documentation/content/doc/toolbar.md
@@ -31,8 +31,14 @@ Rectangle annotations can be tagged with a label. Use the palette in the upper l
 ### Polygon
 
 With the polygon tool selected, the left mouse button places and adjusts control points.
-Click the first control point to finish making the polygon.  
 Before a polygon is finished, right click to remove the last point or press the Esc key to remove all points.
+
+After placing 3 points, you can finish the polygon by
+
+- Clicking the first control point.
+- Press the `Enter` key
+- Double clicking the left mouse button.
+
 After a polygon is closed, right click a control point to delete the polygon.
 
 Polygon annotations can be tagged with a label. Use the palette in the upper left or the `q` or `w` keys to select the active label.

--- a/src/components/tools/polygon/PolygonWidget2D.vue
+++ b/src/components/tools/polygon/PolygonWidget2D.vue
@@ -178,7 +178,7 @@ export default defineComponent({
     const movePoint = computed(() => tool.value?.movePoint);
     watch([movePoint], () => {
       finishable.value =
-        !!widget.value && widget.value.getWidgetState().getFinshable();
+        !!widget.value && widget.value.getWidgetState().getFinishable();
     });
 
     return {

--- a/src/vtk/PolygonWidget/behavior.ts
+++ b/src/vtk/PolygonWidget/behavior.ts
@@ -93,9 +93,9 @@ export default function widgetBehavior(publicAPI: any, model: any) {
     ) {
       model.activeState.setOrigin(worldCoords);
 
-      model.widgetState.setFinshable(isFinishable());
+      model.widgetState.setFinishable(isFinishable());
 
-      if (model.widgetState.getFinshable())
+      if (model.widgetState.getFinishable())
         // snap to first point
         model.activeState.setOrigin(
           model.widgetState.getHandles()[0].getOrigin()
@@ -134,7 +134,7 @@ export default function widgetBehavior(publicAPI: any, model: any) {
       }
       updateActiveStateHandle(e);
 
-      if (model.widgetState.getFinshable()) {
+      if (model.widgetState.getFinishable()) {
         finishPlacing();
         // Don't add another point, just return
         return macro.EVENT_ABORT;

--- a/src/vtk/PolygonWidget/index.d.ts
+++ b/src/vtk/PolygonWidget/index.d.ts
@@ -17,8 +17,8 @@ export interface vtkPolygonWidgetState extends vtkWidgetState {
   clearHandles(): void;
   getPlacing(): boolean;
   setPlacing(is: boolean): void;
-  getFinshable(): boolean;
-  setFinshable(is: boolean): void;
+  getFinishable(): boolean;
+  setFinishable(is: boolean): void;
 }
 
 export interface vtkPolygonViewWidget extends vtkAbstractWidget {

--- a/src/vtk/PolygonWidget/state.ts
+++ b/src/vtk/PolygonWidget/state.ts
@@ -37,8 +37,7 @@ function vtkPolygonWidgetState(publicAPI: any, model: any) {
 
   model.handles = [];
 
-  publicAPI.getHandles = () => model.handles;
-
+  // After deserialize, Pinia store already added points.  Hence addPoint flag.
   publicAPI.addHandle = (addPoint = true) => {
     const index = model.handles.length;
     const handleModel = { index };
@@ -58,6 +57,7 @@ function vtkPolygonWidgetState(publicAPI: any, model: any) {
     publicAPI.bindState(handlePublicAPI, [HandlesLabel]);
     model.handles.push(handlePublicAPI);
     publicAPI.modified();
+
     return handlePublicAPI;
   };
 
@@ -68,24 +68,17 @@ function vtkPolygonWidgetState(publicAPI: any, model: any) {
     }
     model.handles.splice(removeIndex, 1);
 
-    getTool().points.splice(removeIndex, 1);
+    // Tool does not exist if loading new image
+    const tool = getTool();
+    if (tool) tool.points.splice(removeIndex, 1);
 
     publicAPI.modified();
   };
 
   publicAPI.clearHandles = () => {
     while (model.handles.length) {
-      const instance = model.handles.pop();
-      if (instance) {
-        publicAPI.unbindState(instance);
-      }
+      publicAPI.removeHandle(model.handles.length - 1);
     }
-
-    // Tool does not exist if loading new image
-    const tool = getTool();
-    if (tool) tool.points = [];
-
-    publicAPI.modified();
   };
 
   model.labels = {
@@ -99,8 +92,8 @@ function vtkPolygonWidgetState(publicAPI: any, model: any) {
   };
 
   model.finishable = false;
-  publicAPI.getFinshable = () => model.finishable;
-  publicAPI.setFinshable = (is: boolean) => {
+  publicAPI.getFinishable = () => model.finishable;
+  publicAPI.setFinishable = (is: boolean) => {
     model.finishable = is;
   };
 
@@ -124,7 +117,7 @@ function _createPolygonWidgetState(
   vtkWidgetState.extend(publicAPI, model, initialValues);
   bounds.extend(publicAPI, model);
 
-  macro.get(publicAPI, model, ['id']);
+  macro.get(publicAPI, model, ['id', 'handles']);
   macro.moveToProtected(publicAPI, model, ['store']);
 
   vtkPolygonWidgetState(publicAPI, model);


### PR DESCRIPTION
After finish a polygon with the `Enter` key or double clicking the left mouse button.

Closes #389