### PR TITLE
chore(vite.config): move port config to package.json script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "vite",
     "preview": "vite preview",
-    "serve": "npm run dev",
+    "serve": "npm run dev -- --port 8080",
     "build": "vue-tsc --noEmit && vite build",
     "build:analyze": "cross-env ANALYZE_BUNDLE=1 npm run build",
     "test": "vitest",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -145,9 +145,6 @@ export default defineConfig({
       : ({} as Plugin),
     configureSentryPlugin(),
   ],
-  server: {
-    port: 8080,
-  },
   test: {
     environment: 'jsdom',
     // canvas support. See: https://github.com/vitest-dev/vitest/issues/740


### PR DESCRIPTION
I'm finding the new vite port and its fallback logic a little more convenent.  `npm run dev` gets me there now.