### PR TITLE
Annotation Tool Visibility Button

### DIFF
--- a/src/components/LabelmapList.vue
+++ b/src/components/LabelmapList.vue
@@ -6,12 +6,6 @@
   </v-list>
 </template>
 
-<style scoped>
-.empty-state {
-  text-align: center;
-}
-</style>
-
 <script lang="ts">
 import { computed, defineComponent } from 'vue';
 import { useLabelmapStore } from '../store/datasets-labelmaps';

--- a/src/components/MeasurementsRulerList.vue
+++ b/src/components/MeasurementsRulerList.vue
@@ -9,8 +9,8 @@ const toolStore = useRulerStore();
   <measurements-tool-list :toolStore="toolStore" icon="mdi-ruler">
     <template v-slot:details="{ tool }">
       <v-row>
-        <v-col>Slice: {{ tool.slice + 1 }}</v-col>
-        <v-col>Axis: {{ tool.axis }}</v-col>
+        <v-col cols="3">Slice: {{ tool.slice + 1 }}</v-col>
+        <v-col cols="3">Axis: {{ tool.axis }}</v-col>
         <v-col>
           Length:
           <span class="value">

--- a/src/components/MeasurementsToolList.vue
+++ b/src/components/MeasurementsToolList.vue
@@ -47,41 +47,48 @@ const toggleHidden = (id: ToolID) => {
 </script>
 
 <template>
-  <v-list-item v-for="tool in tools" :key="tool.id" lines="two">
-    <template #prepend>
-      <v-icon class="tool-icon">{{ icon }}</v-icon>
-      <div class="color-dot mr-3" :style="{ backgroundColor: tool.color }" />
-    </template>
-    <v-list-item-title v-bind="$attrs">
-      {{ tool.labelName }}
-    </v-list-item-title>
+  <v-list-item v-for="tool in tools" :key="tool.id">
+    <v-container>
+      <v-row class="align-center main-row">
+        <v-icon class="tool-icon">{{ icon }}</v-icon>
+        <div class="color-dot mr-3" :style="{ backgroundColor: tool.color }" />
 
-    <v-list-item-subtitle>
-      <slot name="details" v-bind="{ tool }">
-        <v-row>
-          <v-col>Slice: {{ tool.slice + 1 }}</v-col>
-          <v-col>Axis: {{ tool.axis }}</v-col>
-        </v-row>
-      </slot>
-    </v-list-item-subtitle>
+        <v-list-item-title v-bind="$attrs">
+          {{ tool.labelName }}
+        </v-list-item-title>
 
-    <template #append>
-      <v-btn variant="text" @click="toggleHidden(tool.id)">
-        <v-icon v-if="tool.hidden">mdi-eye-off</v-icon>
-        <v-icon v-else>mdi-eye</v-icon>
-        <v-tooltip location="top" activator="parent">{{
-          tool.hidden ? 'Show' : 'Hide'
-        }}</v-tooltip>
-      </v-btn>
-      <v-btn variant="text" @click="jumpTo(tool.id)">
-        <v-icon>mdi-target</v-icon>
-        <v-tooltip location="top" activator="parent">Reveal Slice</v-tooltip>
-      </v-btn>
-      <v-btn variant="text" @click="remove(tool.id)">
-        <v-icon>mdi-delete</v-icon>
-        <v-tooltip location="top" activator="parent">Delete</v-tooltip>
-      </v-btn>
-    </template>
+        <span class="ml-auto actions">
+          <v-btn icon variant="text" @click="toggleHidden(tool.id)">
+            <v-icon v-if="tool.hidden">mdi-eye-off</v-icon>
+            <v-icon v-else>mdi-eye</v-icon>
+            <v-tooltip location="top" activator="parent">{{
+              tool.hidden ? 'Show' : 'Hide'
+            }}</v-tooltip>
+          </v-btn>
+          <v-btn icon variant="text" @click="jumpTo(tool.id)">
+            <v-icon>mdi-target</v-icon>
+            <v-tooltip location="top" activator="parent"
+              >Reveal Slice</v-tooltip
+            >
+          </v-btn>
+          <v-btn icon variant="text" @click="remove(tool.id)">
+            <v-icon>mdi-delete</v-icon>
+            <v-tooltip location="top" activator="parent">Delete</v-tooltip>
+          </v-btn>
+        </span>
+      </v-row>
+
+      <v-row class="mt-4">
+        <v-list-item-subtitle class="w-100">
+          <slot name="details" v-bind="{ tool }">
+            <v-row>
+              <v-col cols="3">Slice: {{ tool.slice + 1 }}</v-col>
+              <v-col cols="3">Axis: {{ tool.axis }}</v-col>
+            </v-row>
+          </slot>
+        </v-list-item-subtitle>
+      </v-row>
+    </v-container>
   </v-list-item>
 </template>
 
@@ -92,14 +99,24 @@ const toggleHidden = (id: ToolID) => {
   text-align: center;
 }
 
+.main-row {
+  flex-wrap: nowrap;
+}
+
 .color-dot {
   width: 24px;
   height: 24px;
   background: yellow;
   border-radius: 16px;
+  flex-shrink: 0;
 }
 
 .tool-icon {
   margin-inline-end: 12px;
+  opacity: var(--v-medium-emphasis-opacity);
+}
+
+.actions {
+  flex-shrink: 0;
 }
 </style>

--- a/src/components/MeasurementsToolList.vue
+++ b/src/components/MeasurementsToolList.vue
@@ -95,10 +95,6 @@ const toggleHidden = (id: ToolID) => {
 <style src="@/src/components/styles/utils.css"></style>
 
 <style scoped>
-.empty-state {
-  text-align: center;
-}
-
 .main-row {
   flex-wrap: nowrap;
 }

--- a/src/components/MeasurementsToolList.vue
+++ b/src/components/MeasurementsToolList.vue
@@ -67,9 +67,9 @@ const toggleHidden = (id: ToolID) => {
           </v-btn>
           <v-btn icon variant="text" @click="jumpTo(tool.id)">
             <v-icon>mdi-target</v-icon>
-            <v-tooltip location="top" activator="parent"
-              >Reveal Slice</v-tooltip
-            >
+            <v-tooltip location="top" activator="parent">
+              Reveal Slice
+            </v-tooltip>
           </v-btn>
           <v-btn icon variant="text" @click="remove(tool.id)">
             <v-icon>mdi-delete</v-icon>

--- a/src/components/MeasurementsToolList.vue
+++ b/src/components/MeasurementsToolList.vue
@@ -39,6 +39,11 @@ const remove = (id: ToolID) => {
 const jumpTo = (id: ToolID) => {
   props.toolStore.jumpToTool(id);
 };
+
+const toggleHidden = (id: ToolID) => {
+  const toggled = !props.toolStore.toolByID[id].hidden;
+  props.toolStore.updateTool(id, { hidden: toggled });
+};
 </script>
 
 <template>
@@ -59,17 +64,20 @@ const jumpTo = (id: ToolID) => {
         </v-row>
       </slot>
     </v-list-item-subtitle>
+
     <template #append>
-      <v-btn
-        class="mr-2"
-        icon="mdi-target"
-        variant="text"
-        @click="jumpTo(tool.id)"
-      >
-        <v-icon>mdi-target</v-icon>
-        <v-tooltip location="top" activator="parent"> Reveal Slice </v-tooltip>
+      <v-btn variant="text" @click="toggleHidden(tool.id)">
+        <v-icon v-if="tool.hidden">mdi-eye-off</v-icon>
+        <v-icon v-else>mdi-eye</v-icon>
+        <v-tooltip location="top" activator="parent">{{
+          tool.hidden ? 'Show' : 'Hide'
+        }}</v-tooltip>
       </v-btn>
-      <v-btn icon="mdi-delete" variant="text" @click="remove(tool.id)">
+      <v-btn variant="text" @click="jumpTo(tool.id)">
+        <v-icon>mdi-target</v-icon>
+        <v-tooltip location="top" activator="parent">Reveal Slice</v-tooltip>
+      </v-btn>
+      <v-btn variant="text" @click="remove(tool.id)">
         <v-icon>mdi-delete</v-icon>
         <v-tooltip location="top" activator="parent">Delete</v-tooltip>
       </v-btn>

--- a/src/components/tools/AnnotationContextMenu.vue
+++ b/src/components/tools/AnnotationContextMenu.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts" generic="ToolID extends string">
+/* global ToolID:readonly */
+import { shallowReactive } from 'vue';
+import { AnnotationToolStore } from '@/src/store/tools/useAnnotationTool';
+import { ContextMenuEvent } from '@/src/types/annotation-tool';
+import { WidgetAction } from '@/src/vtk/ToolWidgetUtils/utils';
+
+const props = defineProps<{
+  toolStore: AnnotationToolStore<ToolID>;
+}>();
+
+const contextMenu = shallowReactive({
+  show: false,
+  x: 0,
+  y: 0,
+  forToolID: '' as ToolID,
+  widgetActions: [] as Array<WidgetAction>,
+});
+
+const open = (id: ToolID, event: ContextMenuEvent) => {
+  const { displayXY } = event;
+  [contextMenu.x, contextMenu.y] = displayXY;
+  contextMenu.forToolID = id;
+  contextMenu.show = true;
+  contextMenu.widgetActions = event.widgetActions;
+};
+
+defineExpose({
+  open,
+});
+
+const deleteToolFromContextMenu = () => {
+  props.toolStore.removeTool(contextMenu.forToolID);
+};
+
+const hideToolFromContextMenu = () => {
+  props.toolStore.updateTool(contextMenu.forToolID, {
+    hidden: true,
+  });
+};
+</script>
+
+<template>
+  <v-menu
+    v-model="contextMenu.show"
+    class="position-absolute"
+    :style="{
+      top: `${contextMenu.y}px`,
+      left: `${contextMenu.x}px`,
+    }"
+    close-on-click
+    close-on-content-click
+  >
+    <v-list density="compact">
+      <v-list-item @click="hideToolFromContextMenu">
+        <v-list-item-title>Hide</v-list-item-title>
+      </v-list-item>
+      <v-list-item @click="deleteToolFromContextMenu">
+        <v-list-item-title>Delete Annotation</v-list-item-title>
+      </v-list-item>
+      <!-- Optional items below stable item for muscle memory  -->
+      <v-list-item
+        v-for="action in contextMenu.widgetActions"
+        @click="action.func"
+        :key="action.name"
+      >
+        <v-list-item-title>{{ action.name }}</v-list-item-title>
+      </v-list-item>
+    </v-list>
+  </v-menu>
+</template>

--- a/src/components/tools/polygon/PolygonTool.vue
+++ b/src/components/tools/polygon/PolygonTool.vue
@@ -14,7 +14,7 @@
         @placed="onToolPlaced"
       />
     </svg>
-    <AnnotationContextMenu ref="contextMenu" :tool-store="activeToolStore" />
+    <annotation-context-menu ref="contextMenu" :tool-store="activeToolStore" />
   </div>
 </template>
 

--- a/src/components/tools/polygon/PolygonWidget2D.vue
+++ b/src/components/tools/polygon/PolygonWidget2D.vue
@@ -3,7 +3,6 @@ import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
 import {
   computed,
   defineComponent,
-  onBeforeUnmount,
   onMounted,
   onUnmounted,
   PropType,
@@ -16,12 +15,11 @@ import {
 import vtkPlaneManipulator from '@kitware/vtk.js/Widgets/Manipulators/PlaneManipulator';
 import { useCurrentImage } from '@/src/composables/useCurrentImage';
 import { updatePlaneManipulatorFor2DView } from '@/src/utils/manipulators';
-import type { vtkSubscription } from '@kitware/vtk.js/interfaces';
-import { getCSSCoordinatesFromEvent } from '@/src/utils/vtk-helpers';
 import { LPSAxisDir } from '@/src/types/lps';
 import { useVTKCallback } from '@/src/composables/useVTKCallback';
+import { useRightClickContextMenu } from '@/src/composables/annotationTool';
 import { usePolygonStore as useStore } from '@/src/store/tools/polygons';
-import { ContextMenuEvent, PolygonID as ToolID } from '@/src/types/polygon';
+import { PolygonID as ToolID } from '@/src/types/polygon';
 import vtkWidgetFactory, {
   vtkPolygonViewWidget as WidgetView,
 } from '@/src/vtk/PolygonWidget';
@@ -111,29 +109,7 @@ export default defineComponent({
 
     // --- right click handling --- //
 
-    let rightClickSub: vtkSubscription | null = null;
-
-    onMounted(() => {
-      if (!widget.value) {
-        return;
-      }
-      rightClickSub = widget.value.onRightClickEvent((eventData) => {
-        const displayXY = getCSSCoordinatesFromEvent(eventData);
-        if (displayXY) {
-          emit('contextmenu', {
-            displayXY,
-            widgetActions: eventData.widgetActions,
-          } satisfies ContextMenuEvent);
-        }
-      });
-    });
-
-    onBeforeUnmount(() => {
-      if (rightClickSub) {
-        rightClickSub.unsubscribe();
-        rightClickSub = null;
-      }
-    });
+    useRightClickContextMenu(emit, widget);
 
     // --- manipulator --- //
 

--- a/src/components/tools/rectangle/RectangleTool.vue
+++ b/src/components/tools/rectangle/RectangleTool.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="overlay-no-events">
     <svg class="overlay-no-events">
-      <RectangleWidget2D
+      <rectangle-widget-2D
         v-for="tool in tools"
         :key="tool.id"
         :tool-id="tool.id"
@@ -14,7 +14,7 @@
         @placed="onToolPlaced"
       />
     </svg>
-    <AnnotationContextMenu ref="contextMenu" :tool-store="activeToolStore" />
+    <annotation-context-menu ref="contextMenu" :tool-store="activeToolStore" />
   </div>
 </template>
 

--- a/src/components/tools/rectangle/RectangleTool.vue
+++ b/src/components/tools/rectangle/RectangleTool.vue
@@ -14,22 +14,7 @@
         @placed="onToolPlaced"
       />
     </svg>
-    <v-menu
-      v-model="contextMenu.show"
-      class="position-absolute"
-      :style="{
-        top: `${contextMenu.y}px`,
-        left: `${contextMenu.x}px`,
-      }"
-      close-on-click
-      close-on-content-click
-    >
-      <v-list density="compact">
-        <v-list-item @click="deleteToolFromContextMenu">
-          <v-list-item-title>Delete</v-list-item-title>
-        </v-list-item>
-      </v-list>
-    </v-menu>
+    <AnnotationContextMenu ref="contextMenu" :tool-store="activeToolStore" />
   </div>
 </template>
 
@@ -39,7 +24,6 @@ import {
   defineComponent,
   onUnmounted,
   PropType,
-  reactive,
   ref,
   toRefs,
   watch,
@@ -51,12 +35,16 @@ import { useToolStore } from '@/src/store/tools';
 import { Tools } from '@/src/store/tools/types';
 import { getLPSAxisFromDir } from '@/src/utils/lps';
 import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
-import type { Vector2, Vector3 } from '@kitware/vtk.js/types';
+import type { Vector3 } from '@kitware/vtk.js/types';
 import { LPSAxisDir } from '@/src/types/lps';
 import { FrameOfReference } from '@/src/utils/frameOfReference';
 import { useRectangleStore } from '@/src/store/tools/rectangles';
 import { RectangleID } from '@/src/types/rectangle';
-import { useCurrentTools } from '@/src/composables/annotationTool';
+import {
+  useCurrentTools,
+  useContextMenu,
+} from '@/src/composables/annotationTool';
+import AnnotationContextMenu from '@/src/components/tools/AnnotationContextMenu.vue';
 import RectangleWidget2D from './RectangleWidget2D.vue';
 
 type ToolID = RectangleID;
@@ -85,6 +73,7 @@ export default defineComponent({
   },
   components: {
     RectangleWidget2D,
+    AnnotationContextMenu,
   },
   setup(props) {
     const { viewDirection, currentSlice } = toRefs(props);
@@ -189,34 +178,17 @@ export default defineComponent({
       { immediate: true }
     );
 
-    // --- context menu --- //
-
-    const contextMenu = reactive({
-      show: false,
-      x: 0,
-      y: 0,
-      forToolID: '' as ToolID,
-    });
-
-    const openContextMenu = (toolID: ToolID, displayXY: Vector2) => {
-      [contextMenu.x, contextMenu.y] = displayXY;
-      contextMenu.show = true;
-      contextMenu.forToolID = toolID;
-    };
-
-    const deleteToolFromContextMenu = () => {
-      activeToolStore.removeTool(contextMenu.forToolID);
-    };
+    const { contextMenu, openContextMenu } = useContextMenu();
 
     const currentTools = useCurrentTools(activeToolStore, viewAxis);
 
     return {
       tools: currentTools,
       placingToolID,
+      onToolPlaced,
       contextMenu,
       openContextMenu,
-      deleteToolFromContextMenu,
-      onToolPlaced,
+      activeToolStore,
     };
   },
 });

--- a/src/components/tools/rectangle/RectangleWidget2D.vue
+++ b/src/components/tools/rectangle/RectangleWidget2D.vue
@@ -29,6 +29,8 @@ import RectangleSVG2D from '@/src/components/tools/rectangle/RectangleSVG2D.vue'
 import { vtkRulerWidgetPointState } from '@/src/vtk/RulerWidget';
 import { watchOnce } from '@vueuse/core';
 import { RectangleID } from '@/src/types/rectangle';
+import { ContextMenuEvent } from '@/src/types/annotation-tool';
+import { useRightClickContextMenu } from '@/src/composables/annotationTool';
 
 const useStore = useRectangleStore;
 const vtkWidgetFactory = vtkRectangleWidget;
@@ -140,9 +142,12 @@ export default defineComponent({
         return;
       }
       rightClickSub = widget.value.onRightClickEvent((eventData) => {
-        const coords = getCSSCoordinatesFromEvent(eventData);
-        if (coords) {
-          emit('contextmenu', coords);
+        const displayXY = getCSSCoordinatesFromEvent(eventData);
+        if (displayXY) {
+          emit('contextmenu', {
+            displayXY,
+            widgetActions: eventData.widgetActions,
+          } satisfies ContextMenuEvent);
         }
       });
     });
@@ -153,6 +158,8 @@ export default defineComponent({
         rightClickSub = null;
       }
     });
+
+    useRightClickContextMenu(emit, widget);
 
     // --- manipulator --- //
 

--- a/src/components/tools/rectangle/RectangleWidget2D.vue
+++ b/src/components/tools/rectangle/RectangleWidget2D.vue
@@ -3,7 +3,6 @@ import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
 import {
   computed,
   defineComponent,
-  onBeforeUnmount,
   onMounted,
   onUnmounted,
   PropType,
@@ -16,8 +15,6 @@ import {
 import vtkPlaneManipulator from '@kitware/vtk.js/Widgets/Manipulators/PlaneManipulator';
 import { useCurrentImage } from '@/src/composables/useCurrentImage';
 import { updatePlaneManipulatorFor2DView } from '@/src/utils/manipulators';
-import type { vtkSubscription } from '@kitware/vtk.js/interfaces';
-import { getCSSCoordinatesFromEvent } from '@/src/utils/vtk-helpers';
 import { LPSAxisDir } from '@/src/types/lps';
 import { useVTKCallback } from '@/src/composables/useVTKCallback';
 import { useRectangleStore } from '@/src/store/tools/rectangles';
@@ -29,7 +26,6 @@ import RectangleSVG2D from '@/src/components/tools/rectangle/RectangleSVG2D.vue'
 import { vtkRulerWidgetPointState } from '@/src/vtk/RulerWidget';
 import { watchOnce } from '@vueuse/core';
 import { RectangleID } from '@/src/types/rectangle';
-import { ContextMenuEvent } from '@/src/types/annotation-tool';
 import { useRightClickContextMenu } from '@/src/composables/annotationTool';
 
 const useStore = useRectangleStore;
@@ -134,30 +130,6 @@ export default defineComponent({
     });
 
     // --- right click handling --- //
-
-    let rightClickSub: vtkSubscription | null = null;
-
-    onMounted(() => {
-      if (!widget.value) {
-        return;
-      }
-      rightClickSub = widget.value.onRightClickEvent((eventData) => {
-        const displayXY = getCSSCoordinatesFromEvent(eventData);
-        if (displayXY) {
-          emit('contextmenu', {
-            displayXY,
-            widgetActions: eventData.widgetActions,
-          } satisfies ContextMenuEvent);
-        }
-      });
-    });
-
-    onBeforeUnmount(() => {
-      if (rightClickSub) {
-        rightClickSub.unsubscribe();
-        rightClickSub = null;
-      }
-    });
 
     useRightClickContextMenu(emit, widget);
 

--- a/src/components/tools/ruler/RulerTool.vue
+++ b/src/components/tools/ruler/RulerTool.vue
@@ -14,22 +14,7 @@
         @placed="onRulerPlaced"
       />
     </svg>
-    <v-menu
-      v-model="contextMenu.show"
-      class="position-absolute"
-      :style="{
-        top: `${contextMenu.y}px`,
-        left: `${contextMenu.x}px`,
-      }"
-      close-on-click
-      close-on-content-click
-    >
-      <v-list density="compact">
-        <v-list-item @click="deleteRulerFromContextMenu">
-          <v-list-item-title>Delete</v-list-item-title>
-        </v-list-item>
-      </v-list>
-    </v-menu>
+    <AnnotationContextMenu ref="contextMenu" :tool-store="rulerStore" />
   </div>
 </template>
 
@@ -39,7 +24,6 @@ import {
   defineComponent,
   onUnmounted,
   PropType,
-  reactive,
   ref,
   toRefs,
   watch,
@@ -51,12 +35,16 @@ import { useRulerStore } from '@/src/store/tools/rulers';
 import { getLPSAxisFromDir } from '@/src/utils/lps';
 import RulerWidget2D from '@/src/components/tools/ruler/RulerWidget2D.vue';
 import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
-import type { Vector2, Vector3 } from '@kitware/vtk.js/types';
+import type { Vector3 } from '@kitware/vtk.js/types';
 import { LPSAxisDir } from '@/src/types/lps';
 import { storeToRefs } from 'pinia';
 import { FrameOfReference } from '@/src/utils/frameOfReference';
 import { vec3 } from 'gl-matrix';
-import { useCurrentTools } from '@/src/composables/annotationTool';
+import {
+  useContextMenu,
+  useCurrentTools,
+} from '@/src/composables/annotationTool';
+import AnnotationContextMenu from '@/src/components/tools/AnnotationContextMenu.vue';
 
 export default defineComponent({
   name: 'RulerTool',
@@ -80,6 +68,7 @@ export default defineComponent({
   },
   components: {
     RulerWidget2D,
+    AnnotationContextMenu,
   },
   setup(props) {
     const { viewDirection, currentSlice } = toRefs(props);
@@ -187,24 +176,7 @@ export default defineComponent({
       { immediate: true }
     );
 
-    // --- context menu --- //
-
-    const contextMenu = reactive({
-      show: false,
-      x: 0,
-      y: 0,
-      forRulerID: '',
-    });
-
-    const openContextMenu = (rulerID: string, displayXY: Vector2) => {
-      [contextMenu.x, contextMenu.y] = displayXY;
-      contextMenu.show = true;
-      contextMenu.forRulerID = rulerID;
-    };
-
-    const deleteRulerFromContextMenu = () => {
-      rulerStore.removeRuler(contextMenu.forRulerID);
-    };
+    const { contextMenu, openContextMenu } = useContextMenu();
 
     // --- ruler data --- //
 
@@ -221,10 +193,10 @@ export default defineComponent({
     return {
       rulers: currentRulers,
       placingRulerID,
+      onRulerPlaced,
       contextMenu,
       openContextMenu,
-      deleteRulerFromContextMenu,
-      onRulerPlaced,
+      rulerStore,
     };
   },
 });

--- a/src/components/tools/ruler/RulerTool.vue
+++ b/src/components/tools/ruler/RulerTool.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="overlay-no-events">
     <svg class="overlay-no-events">
-      <RulerWidget2D
+      <ruler-widget-2D
         v-for="ruler in rulers"
         :key="ruler.id"
         :ruler-id="ruler.id"
@@ -14,7 +14,7 @@
         @placed="onRulerPlaced"
       />
     </svg>
-    <AnnotationContextMenu ref="contextMenu" :tool-store="rulerStore" />
+    <annotation-context-menu ref="contextMenu" :tool-store="rulerStore" />
   </div>
 </template>
 

--- a/src/components/tools/ruler/RulerWidget2D.vue
+++ b/src/components/tools/ruler/RulerWidget2D.vue
@@ -8,7 +8,6 @@ import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
 import {
   computed,
   defineComponent,
-  onBeforeUnmount,
   onMounted,
   onUnmounted,
   PropType,
@@ -21,13 +20,12 @@ import {
 import vtkPlaneManipulator from '@kitware/vtk.js/Widgets/Manipulators/PlaneManipulator';
 import { useCurrentImage } from '@/src/composables/useCurrentImage';
 import { updatePlaneManipulatorFor2DView } from '@/src/utils/manipulators';
-import type { vtkSubscription } from '@kitware/vtk.js/interfaces';
-import { getCSSCoordinatesFromEvent } from '@/src/utils/vtk-helpers';
 import { LPSAxisDir } from '@/src/types/lps';
 import { useRulerStore } from '@/src/store/tools/rulers';
 import { useVTKCallback } from '@/src/composables/useVTKCallback';
 import RulerSVG2D from '@/src/components/tools/ruler/RulerSVG2D.vue';
 import { watchOnce } from '@vueuse/core';
+import { useRightClickContextMenu } from '@/src/composables/annotationTool';
 
 export default defineComponent({
   name: 'RulerWidget2D',
@@ -123,26 +121,7 @@ export default defineComponent({
 
     // --- right click handling --- //
 
-    let rightClickSub: vtkSubscription | null = null;
-
-    onMounted(() => {
-      if (!widget.value) {
-        return;
-      }
-      rightClickSub = widget.value.onRightClickEvent((eventData) => {
-        const coords = getCSSCoordinatesFromEvent(eventData);
-        if (coords) {
-          emit('contextmenu', coords);
-        }
-      });
-    });
-
-    onBeforeUnmount(() => {
-      if (rightClickSub) {
-        rightClickSub.unsubscribe();
-        rightClickSub = null;
-      }
-    });
+    useRightClickContextMenu(emit, widget);
 
     // --- manipulator --- //
 

--- a/src/composables/annotationTool.ts
+++ b/src/composables/annotationTool.ts
@@ -1,9 +1,13 @@
+import { Ref, computed, onBeforeUnmount, onMounted, ref } from 'vue';
+import { vtkSubscription } from '@kitware/vtk.js/interfaces';
+import AnnotationContextMenu from '@/src/components/tools/AnnotationContextMenu.vue';
 import { useCurrentImage } from '@/src/composables/useCurrentImage';
 import { frameOfReferenceToImageSliceAndAxis } from '@/src/utils/frameOfReference';
-import { Ref, computed } from 'vue';
+import { vtkAnnotationToolWidget } from '@/src/vtk/ToolWidgetUtils/utils';
 import { LPSAxis } from '../types/lps';
-import { AnnotationTool } from '../types/annotation-tool';
+import { AnnotationTool, ContextMenuEvent } from '../types/annotation-tool';
 import { AnnotationToolStore } from '../store/tools/useAnnotationTool';
+import { getCSSCoordinatesFromEvent } from '../utils/vtk-helpers';
 
 // does the tools's frame of reference match
 // the view's axis
@@ -45,3 +49,52 @@ export const useCurrentTools = <ToolID extends string>(
       );
     });
   });
+
+// --- Context Menu --- //
+
+export const useContextMenu = <ToolID extends string>() => {
+  // open function typing workaround until this fixed
+  // https://github.com/vuejs/core/issues/8373
+  const contextMenu = ref<
+    | (ReturnType<typeof AnnotationContextMenu<ToolID>> & {
+        open: (id: ToolID, e: ContextMenuEvent) => void;
+      })
+    | null
+  >(null);
+  const openContextMenu = (toolID: ToolID, event: ContextMenuEvent) => {
+    if (!contextMenu.value)
+      throw new Error('contextMenu component does not exist');
+    contextMenu.value.open(toolID, event);
+  };
+
+  return { contextMenu, openContextMenu };
+};
+
+export const useRightClickContextMenu = (
+  emit: (event: 'contextmenu', ...args: any[]) => void,
+  widget: Ref<vtkAnnotationToolWidget | null>
+) => {
+  let rightClickSub: vtkSubscription | null = null;
+
+  onMounted(() => {
+    if (!widget.value) {
+      return;
+    }
+    rightClickSub = widget.value.onRightClickEvent((eventData) => {
+      const displayXY = getCSSCoordinatesFromEvent(eventData);
+      if (displayXY) {
+        emit('contextmenu', {
+          displayXY,
+          widgetActions: eventData.widgetActions,
+        } satisfies ContextMenuEvent);
+      }
+    });
+  });
+
+  onBeforeUnmount(() => {
+    if (rightClickSub) {
+      rightClickSub.unsubscribe();
+      rightClickSub = null;
+    }
+  });
+};

--- a/src/composables/annotationTool.ts
+++ b/src/composables/annotationTool.ts
@@ -1,6 +1,4 @@
-import { Ref, computed, onBeforeUnmount, onMounted, ref } from 'vue';
-import { vtkSubscription } from '@kitware/vtk.js/interfaces';
-import AnnotationContextMenu from '@/src/components/tools/AnnotationContextMenu.vue';
+import { Ref, computed, ref } from 'vue';
 import { useCurrentImage } from '@/src/composables/useCurrentImage';
 import { frameOfReferenceToImageSliceAndAxis } from '@/src/utils/frameOfReference';
 import { vtkAnnotationToolWidget } from '@/src/vtk/ToolWidgetUtils/utils';
@@ -8,6 +6,7 @@ import { LPSAxis } from '../types/lps';
 import { AnnotationTool, ContextMenuEvent } from '../types/annotation-tool';
 import { AnnotationToolStore } from '../store/tools/useAnnotationTool';
 import { getCSSCoordinatesFromEvent } from '../utils/vtk-helpers';
+import { useVTKCallback } from './useVTKCallback';
 
 // does the tools's frame of reference match
 // the view's axis
@@ -53,14 +52,9 @@ export const useCurrentTools = <ToolID extends string>(
 // --- Context Menu --- //
 
 export const useContextMenu = <ToolID extends string>() => {
-  // open function typing workaround until this fixed
-  // https://github.com/vuejs/core/issues/8373
-  const contextMenu = ref<
-    | (ReturnType<typeof AnnotationContextMenu<ToolID>> & {
-        open: (id: ToolID, e: ContextMenuEvent) => void;
-      })
-    | null
-  >(null);
+  const contextMenu = ref<{
+    open: (id: ToolID, e: ContextMenuEvent) => void;
+  } | null>(null);
   const openContextMenu = (toolID: ToolID, event: ContextMenuEvent) => {
     if (!contextMenu.value)
       throw new Error('contextMenu component does not exist');
@@ -74,27 +68,16 @@ export const useRightClickContextMenu = (
   emit: (event: 'contextmenu', ...args: any[]) => void,
   widget: Ref<vtkAnnotationToolWidget | null>
 ) => {
-  let rightClickSub: vtkSubscription | null = null;
+  const widgetOnRightClick = computed(() => widget.value?.onRightClickEvent);
+  const onRightClick = useVTKCallback(widgetOnRightClick);
 
-  onMounted(() => {
-    if (!widget.value) {
-      return;
-    }
-    rightClickSub = widget.value.onRightClickEvent((eventData) => {
-      const displayXY = getCSSCoordinatesFromEvent(eventData);
-      if (displayXY) {
-        emit('contextmenu', {
-          displayXY,
-          widgetActions: eventData.widgetActions,
-        } satisfies ContextMenuEvent);
-      }
-    });
-  });
-
-  onBeforeUnmount(() => {
-    if (rightClickSub) {
-      rightClickSub.unsubscribe();
-      rightClickSub = null;
+  onRightClick((eventData) => {
+    const displayXY = getCSSCoordinatesFromEvent(eventData);
+    if (displayXY) {
+      emit('contextmenu', {
+        displayXY,
+        widgetActions: eventData.widgetActions,
+      } satisfies ContextMenuEvent);
     }
   });
 };

--- a/src/composables/annotationTool.ts
+++ b/src/composables/annotationTool.ts
@@ -1,0 +1,47 @@
+import { useCurrentImage } from '@/src/composables/useCurrentImage';
+import { frameOfReferenceToImageSliceAndAxis } from '@/src/utils/frameOfReference';
+import { Ref, computed } from 'vue';
+import { LPSAxis } from '../types/lps';
+import { AnnotationTool } from '../types/annotation-tool';
+import { AnnotationToolStore } from '../store/tools/useAnnotationTool';
+
+// does the tools's frame of reference match
+// the view's axis
+const useDoesToolFrameMatchViewAxis = <
+  ToolID extends string,
+  Tool extends AnnotationTool<ToolID>
+>(
+  viewAxis: Ref<LPSAxis>,
+  tool: Partial<Tool>
+) => {
+  if (!tool.frameOfReference) return false;
+
+  const { currentImageMetadata } = useCurrentImage();
+  const toolAxis = frameOfReferenceToImageSliceAndAxis(
+    tool.frameOfReference,
+    currentImageMetadata.value,
+    {
+      allowOutOfBoundsSlice: true,
+    }
+  );
+  return !!toolAxis && toolAxis.axis === viewAxis.value;
+};
+
+export const useCurrentTools = <ToolID extends string>(
+  toolStore: AnnotationToolStore<ToolID>,
+  viewAxis: Ref<LPSAxis>
+) =>
+  computed(() => {
+    const { currentImageID } = useCurrentImage();
+    const curImageID = currentImageID.value;
+
+    return toolStore.tools.filter((tool) => {
+      // only show tools for the current image,
+      // current view axis and not hidden
+      return (
+        tool.imageID === curImageID &&
+        useDoesToolFrameMatchViewAxis(viewAxis, tool) &&
+        !tool.hidden
+      );
+    });
+  });

--- a/src/store/__tests__/rulers.spec.ts
+++ b/src/store/__tests__/rulers.spec.ts
@@ -11,7 +11,7 @@ chai.use(chaiSubset);
 
 function createRuler(): RequiredWithPartial<
   Ruler,
-  'id' | 'color' | 'label' | 'labelName'
+  'id' | 'color' | 'label' | 'labelName' | 'hidden'
 > {
   return {
     firstPoint: [1, 1, 1],

--- a/src/store/tools/useAnnotationTool.ts
+++ b/src/store/tools/useAnnotationTool.ts
@@ -1,4 +1,4 @@
-import { Ref, computed, ref, watch } from 'vue';
+import { Ref, UnwrapNestedRefs, computed, ref, watch } from 'vue';
 import { Store, StoreActions, StoreGetters, StoreState } from 'pinia';
 
 import { Maybe, PartialWithRequired } from '@/src/types';
@@ -208,10 +208,6 @@ type UseAnnotationTool<ID extends string> = ReturnType<
   typeof useAnnotationTool<ToolFactory<ID>, unknown>
 >;
 
-type UnwrapRefs<Refs> = {
-  [K in keyof Refs]: Refs[K] extends Ref<infer T> ? T : never;
-};
-
 type UseAnnotationToolNoSerialize<ID extends string> = Omit<
   UseAnnotationTool<ID>,
   'serialize' | 'deserialize'
@@ -219,8 +215,8 @@ type UseAnnotationToolNoSerialize<ID extends string> = Omit<
 
 export type AnnotationToolStore<
   ID extends string,
-  UseAnnotatoinTool = UseAnnotationToolNoSerialize<ID>
-> = StoreState<UseAnnotatoinTool> &
-  StoreActions<UseAnnotatoinTool> &
-  UnwrapRefs<StoreGetters<UseAnnotatoinTool>> & // adds computed props like tools
+  UseAnnotationToolWithID = UseAnnotationToolNoSerialize<ID>
+> = StoreState<UseAnnotationToolWithID> &
+  StoreActions<UseAnnotationToolWithID> &
+  UnwrapNestedRefs<StoreGetters<UseAnnotationToolWithID>> & // adds computed props like tools
   Store; // adds Pinia plugins;

--- a/src/store/tools/useAnnotationTool.ts
+++ b/src/store/tools/useAnnotationTool.ts
@@ -1,5 +1,5 @@
 import { Ref, computed, ref, watch } from 'vue';
-import { Store, StoreActions, StoreState } from 'pinia';
+import { Store, StoreActions, StoreGetters, StoreState } from 'pinia';
 
 import { Maybe, PartialWithRequired } from '@/src/types';
 import { TOOL_COLORS } from '@/src/config';
@@ -208,11 +208,19 @@ type UseAnnotationTool<ID extends string> = ReturnType<
   typeof useAnnotationTool<ToolFactory<ID>, unknown>
 >;
 
+type UnwrapRefs<Refs> = {
+  [K in keyof Refs]: Refs[K] extends Ref<infer T> ? T : never;
+};
+
 type UseAnnotationToolNoSerialize<ID extends string> = Omit<
   UseAnnotationTool<ID>,
   'serialize' | 'deserialize'
 >;
-export type AnnotationToolStore<ID extends string> = StoreState<
-  UseAnnotationToolNoSerialize<ID>
-> &
-  StoreActions<UseAnnotationToolNoSerialize<ID>>;
+
+export type AnnotationToolStore<
+  ID extends string,
+  UseAnnotatoinTool = UseAnnotationToolNoSerialize<ID>
+> = StoreState<UseAnnotatoinTool> &
+  StoreActions<UseAnnotatoinTool> &
+  UnwrapRefs<StoreGetters<UseAnnotatoinTool>> & // adds computed props like tools
+  Store; // adds Pinia plugins;

--- a/src/types/annotation-tool.ts
+++ b/src/types/annotation-tool.ts
@@ -13,7 +13,7 @@ export type AnnotationTool<ID extends string> = {
   frameOfReference: FrameOfReference;
 
   /**
-   * Is this tool in placing mode
+   * Is this tool unfinished?
    */
   placing?: boolean;
 
@@ -22,4 +22,6 @@ export type AnnotationTool<ID extends string> = {
 
   color: string;
   name: string;
+
+  hidden?: boolean;
 };

--- a/src/types/annotation-tool.ts
+++ b/src/types/annotation-tool.ts
@@ -1,4 +1,6 @@
+import type { Vector2 } from '@kitware/vtk.js/types';
 import { FrameOfReference } from '../utils/frameOfReference';
+import { WidgetAction } from '../vtk/ToolWidgetUtils/utils';
 
 export type AnnotationTool<ID extends string> = {
   id: ID;
@@ -24,4 +26,9 @@ export type AnnotationTool<ID extends string> = {
   name: string;
 
   hidden?: boolean;
+};
+
+export type ContextMenuEvent = {
+  displayXY: Vector2;
+  widgetActions: Array<WidgetAction>;
 };

--- a/src/types/polygon.ts
+++ b/src/types/polygon.ts
@@ -1,6 +1,5 @@
-import type { Vector2, Vector3 } from '@kitware/vtk.js/types';
+import type { Vector3 } from '@kitware/vtk.js/types';
 import { AnnotationTool } from './annotation-tool';
-import { WidgetAction } from '../vtk/ToolWidgetUtils/utils';
 
 export type PolygonID = string & { __type: 'PolygonID' };
 
@@ -11,8 +10,3 @@ export type Polygon = {
   points: Array<Vector3>;
   movePoint: Vector3;
 } & AnnotationTool<PolygonID>;
-
-export type ContextMenuEvent = {
-  displayXY: Vector2;
-  widgetActions: Array<WidgetAction>;
-};

--- a/src/vtk/PolygonWidget/index.d.ts
+++ b/src/vtk/PolygonWidget/index.d.ts
@@ -2,8 +2,9 @@ import { vtkSubscription } from '@kitware/vtk.js/interfaces';
 import vtkAbstractWidget from '@kitware/vtk.js/Widgets/Core/AbstractWidget';
 import vtkAbstractWidgetFactory from '@kitware/vtk.js/Widgets/Core/AbstractWidgetFactory';
 import vtkPlaneManipulator from '@kitware/vtk.js/Widgets/Manipulators/PlaneManipulator';
-import { usePolygonStore } from '@/src/store/tools/polygons';
 import vtkWidgetState from '@kitware/vtk.js/Widgets/Core/WidgetState';
+import { usePolygonStore } from '@/src/store/tools/polygons';
+import { vtkAnnotationToolWidget } from '../ToolWidgetUtils/utils';
 
 export interface vtkPolygonWidgetPointState extends vtkWidgetState {
   getVisible(): boolean;
@@ -18,12 +19,7 @@ export interface vtkPolygonWidgetState extends vtkWidgetState {
   setFinishable(is: boolean): void;
 }
 
-export interface vtkPolygonViewWidget extends vtkAbstractWidget {
-  setManipulator(manipulator: vtkPlaneManipulator): boolean;
-  getManipulator(): vtkPlaneManipulator;
-  onRightClickEvent(cb: (eventData: any) => void): vtkSubscription;
-  onPlacedEvent(cb: (eventData: any) => void): vtkSubscription;
-  resetInteractions(): void;
+export interface vtkPolygonViewWidget extends vtkAnnotationToolWidget {
   getWidgetState(): vtkPolygonWidgetState;
 }
 

--- a/src/vtk/PolygonWidget/state.ts
+++ b/src/vtk/PolygonWidget/state.ts
@@ -74,7 +74,7 @@ function vtkPolygonWidgetState(publicAPI: any, model: any) {
     }
 
     publicAPI.bindState(handlePublicAPI, [HandlesLabel]);
-    // bind state pushes handle at end of labels array,
+    // bindState pushes handle at end of labels array,
     // but we may have inserted handle in middle of array.
     // Downstream WidgetRepresentations get order of
     // state/handles from internal HandlesLabel array.

--- a/src/vtk/PolygonWidget/state.ts
+++ b/src/vtk/PolygonWidget/state.ts
@@ -76,8 +76,8 @@ function vtkPolygonWidgetState(publicAPI: any, model: any) {
     publicAPI.bindState(handlePublicAPI, [HandlesLabel]);
     // bind state pushes handle at end of labels array,
     // but we may have inserted handle in middle of array.
-    // Downstream representations get order of state/handles from
-    // internal HandlesLabel labels array.
+    // Downstream WidgetRepresentations get order of
+    // state/handles from internal HandlesLabel array.
     // So copy handles array.
     model.labels[HandlesLabel] = [...model.handles];
 

--- a/src/vtk/RulerWidget/index.d.ts
+++ b/src/vtk/RulerWidget/index.d.ts
@@ -5,6 +5,7 @@ import vtkPlaneManipulator from '@kitware/vtk.js/Widgets/Manipulators/PlaneManip
 import { InteractionState } from './behavior';
 import { useRulerStore } from '@/src/store/tools/rulers';
 import vtkWidgetState from '@kitware/vtk.js/Widgets/Core/WidgetState';
+import { vtkAnnotationToolWidget } from '../ToolWidgetUtils/utils';
 
 export { InteractionState } from './behavior';
 
@@ -19,14 +20,7 @@ export interface vtkRulerWidgetState extends vtkWidgetState {
   getSecondPoint(): vtkRulerWidgetPointState;
 }
 
-export interface vtkRulerViewWidget extends vtkAbstractWidget {
-  setManipulator(manipulator: vtkPlaneManipulator): boolean;
-  getManipulator(): vtkPlaneManipulator;
-  onRightClickEvent(cb: (eventData: any) => void): vtkSubscription;
-  onPlacedEvent(cb: (eventData: any) => void): vtkSubscription;
-  setInteractionState(state: InteractionState): boolean;
-  getInteractionState(): InteractionState;
-  resetInteractions(): void;
+export interface vtkRulerViewWidget extends vtkAnnotationToolWidget {
   getWidgetState(): vtkRulerWidgetState;
 }
 

--- a/src/vtk/RulerWidget/index.d.ts
+++ b/src/vtk/RulerWidget/index.d.ts
@@ -21,6 +21,8 @@ export interface vtkRulerWidgetState extends vtkWidgetState {
 }
 
 export interface vtkRulerViewWidget extends vtkAnnotationToolWidget {
+  setInteractionState(state: InteractionState): boolean;
+  getInteractionState(): InteractionState;
   getWidgetState(): vtkRulerWidgetState;
 }
 

--- a/src/vtk/ToolWidgetUtils/utils.ts
+++ b/src/vtk/ToolWidgetUtils/utils.ts
@@ -1,3 +1,7 @@
+import vtkAbstractWidget from '@kitware/vtk.js/Widgets/Core/AbstractWidget';
+import vtkPlaneManipulator from '@kitware/vtk.js/Widgets/Manipulators/PlaneManipulator';
+import { vtkSubscription } from '@kitware/vtk.js/interfaces';
+
 export function watchState(
   publicAPI: any,
   state: any,
@@ -16,3 +20,11 @@ export type WidgetAction = {
   name: string;
   func: () => void;
 };
+
+export interface vtkAnnotationToolWidget extends vtkAbstractWidget {
+  setManipulator(manipulator: vtkPlaneManipulator): boolean;
+  getManipulator(): vtkPlaneManipulator;
+  onRightClickEvent(cb: (eventData: any) => void): vtkSubscription;
+  onPlacedEvent(cb: (eventData: any) => void): vtkSubscription;
+  resetInteractions(): void;
+}


### PR DESCRIPTION
Adds an eyeball button in the MeasurmentToolList to toggle `hidden` state of annotation tools. 
![image](https://github.com/Kitware/VolView/assets/16823231/d5844e24-d784-4d4e-8063-3948079582e3)

Also adds "Hide" option to right click context menu on annotations.