### PR TITLE
chore(github): no E2E testing on windows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, macos-latest]
     name: E2E Testing on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
The windows test is flaky and requires some more investigation. In the meantime, we won't test on windows.