### PR TITLE
Simplify placing tools

### DIFF
--- a/src/components/tools/polygon/PolygonSVG2D.vue
+++ b/src/components/tools/polygon/PolygonSVG2D.vue
@@ -37,6 +37,7 @@ import {
   watch,
   inject,
 } from 'vue';
+import { Maybe } from '@/src/types';
 
 const POINT_RADIUS = 10;
 const FINISHABLE_POINT_RADIUS = 16;
@@ -53,7 +54,7 @@ export default defineComponent({
       required: true,
     },
     movePoint: {
-      type: Array as unknown as PropType<Vector3>,
+      type: Array as unknown as PropType<Maybe<Vector3>>,
     },
     placing: {
       type: Boolean,

--- a/src/components/tools/polygon/common.ts
+++ b/src/components/tools/polygon/common.ts
@@ -1,0 +1,34 @@
+import { onVTKEvent } from '@/src/composables/onVTKEvent';
+import { Maybe } from '@/src/types';
+import vtkPolygonWidget, {
+  vtkPolygonWidgetState,
+} from '@/src/vtk/PolygonWidget';
+import { Vector3 } from '@kitware/vtk.js/types';
+import { shallowReactive } from 'vue';
+
+export interface PolygonInitState {
+  points: Vector3[];
+}
+
+export function useSyncedPolygonState(widgetFactory: vtkPolygonWidget) {
+  const syncedState = shallowReactive({
+    points: [] as Vector3[],
+    movePoint: null as Maybe<Vector3>,
+    finishable: false,
+  });
+
+  const widgetState = widgetFactory.getWidgetState() as vtkPolygonWidgetState;
+  const syncState = () => {
+    syncedState.points = widgetState
+      .getHandleList()
+      .map((handle) => handle.getOrigin())
+      .filter((pt): pt is Vector3 => !!pt);
+    syncedState.movePoint = widgetState.getMoveHandle().getOrigin();
+    syncedState.finishable = widgetState.getFinishable();
+  };
+
+  onVTKEvent(widgetState, 'onModified', () => syncState());
+  syncState();
+
+  return syncedState;
+}

--- a/src/components/tools/rectangle/RectangleSVG2D.vue
+++ b/src/components/tools/rectangle/RectangleSVG2D.vue
@@ -49,6 +49,7 @@ import {
   watch,
   inject,
 } from 'vue';
+import { Maybe } from '@/src/types';
 
 type SVGPoint = {
   x: number;
@@ -57,8 +58,8 @@ type SVGPoint = {
 
 export default defineComponent({
   props: {
-    point1: Array as PropType<Array<number>>,
-    point2: Array as PropType<Array<number>>,
+    point1: Array as PropType<Maybe<Array<number>>>,
+    point2: Array as PropType<Maybe<Array<number>>>,
     color: String,
     fillColor: String,
     viewId: {

--- a/src/components/tools/rectangle/RectangleTool.vue
+++ b/src/components/tools/rectangle/RectangleTool.vue
@@ -5,12 +5,20 @@
         v-for="tool in tools"
         :key="tool.id"
         :tool-id="tool.id"
-        :is-placing="tool.id === placingToolID"
         :current-slice="currentSlice"
         :view-id="viewId"
         :view-direction="viewDirection"
         :widget-manager="widgetManager"
         @contextmenu="openContextMenu(tool.id, $event)"
+      />
+      <placing-rectangle-widget-2D
+        v-if="isToolActive"
+        :current-slice="currentSlice"
+        :color="activeLabelProps.color"
+        :fill-color="activeLabelProps.fillColor"
+        :view-id="viewId"
+        :view-direction="viewDirection"
+        :widget-manager="widgetManager"
         @placed="onToolPlaced"
       />
     </svg>
@@ -19,35 +27,25 @@
 </template>
 
 <script lang="ts">
-import {
-  computed,
-  defineComponent,
-  onUnmounted,
-  PropType,
-  ref,
-  toRefs,
-  watch,
-} from 'vue';
+import { computed, defineComponent, PropType, toRefs } from 'vue';
 import { storeToRefs } from 'pinia';
-import { vec3 } from 'gl-matrix';
 import { useCurrentImage } from '@/src/composables/useCurrentImage';
 import { useToolStore } from '@/src/store/tools';
 import { Tools } from '@/src/store/tools/types';
 import { getLPSAxisFromDir } from '@/src/utils/lps';
 import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
-import type { Vector3 } from '@kitware/vtk.js/types';
 import { LPSAxisDir } from '@/src/types/lps';
-import { FrameOfReference } from '@/src/utils/frameOfReference';
 import { useRectangleStore } from '@/src/store/tools/rectangles';
-import { RectangleID } from '@/src/types/rectangle';
 import {
   useCurrentTools,
   useContextMenu,
 } from '@/src/composables/annotationTool';
 import AnnotationContextMenu from '@/src/components/tools/AnnotationContextMenu.vue';
+import PlacingRectangleWidget2D from '@/src/components/tools/rectangle/PlacingRectangleWidget2D.vue';
+import { useCurrentFrameOfReference } from '@/src/composables/useCurrentFrameOfReference';
+import { RectangleInitState } from '@/src/components/tools/rectangle/common';
 import RectangleWidget2D from './RectangleWidget2D.vue';
 
-type ToolID = RectangleID;
 const useActiveToolStore = useRectangleStore;
 const toolType = Tools.Rectangle;
 
@@ -73,6 +71,7 @@ export default defineComponent({
   },
   components: {
     RectangleWidget2D,
+    PlacingRectangleWidget2D,
     AnnotationContextMenu,
   },
   setup(props) {
@@ -81,114 +80,49 @@ export default defineComponent({
     const activeToolStore = useActiveToolStore();
     const { activeLabel } = storeToRefs(activeToolStore);
 
-    const { currentImageID, currentImageMetadata } = useCurrentImage();
+    const { currentImageID } = useCurrentImage();
     const isToolActive = computed(() => toolStore.currentTool === toolType);
     const viewAxis = computed(() => getLPSAxisFromDir(viewDirection.value));
 
-    const placingToolID = ref<ToolID | null>(null);
-
-    // --- active tool management --- //
-
-    watch(
-      placingToolID,
-      (id, prevId) => {
-        if (prevId != null) {
-          activeToolStore.updateTool(prevId, { placing: false });
-        }
-        if (id != null) {
-          activeToolStore.updateTool(id, { placing: true });
-        }
-      },
-      { immediate: true }
+    const currentFrameOfReference = useCurrentFrameOfReference(
+      viewDirection,
+      currentSlice
     );
 
-    watch(
-      [isToolActive, currentImageID] as const,
-      ([active, imageID]) => {
-        if (placingToolID.value != null) {
-          activeToolStore.removeTool(placingToolID.value);
-          placingToolID.value = null;
-        }
-        if (active && imageID) {
-          placingToolID.value = activeToolStore.addTool({
-            imageID,
-            placing: true,
-          });
-        }
-      },
-      { immediate: true }
-    );
-
-    watch(
-      [activeLabel, placingToolID],
-      ([label, placingTool]) => {
-        if (placingTool != null) {
-          activeToolStore.updateTool(placingTool, {
-            label,
-            ...(label && activeToolStore.labels[label]),
-          });
-        }
-      },
-      { immediate: true }
-    );
-
-    onUnmounted(() => {
-      if (placingToolID.value != null) {
-        activeToolStore.removeTool(placingToolID.value);
-        placingToolID.value = null;
-      }
-    });
-
-    const onToolPlaced = () => {
-      if (currentImageID.value) {
-        placingToolID.value = activeToolStore.addTool({
-          imageID: currentImageID.value,
-          placing: true,
-        });
-      }
+    const onToolPlaced = (initState: RectangleInitState) => {
+      if (!currentImageID.value) return;
+      activeToolStore.addTool({
+        imageID: currentImageID.value,
+        frameOfReference: currentFrameOfReference.value,
+        slice: currentSlice.value,
+        label: activeLabel.value,
+        color: activeLabel.value
+          ? activeToolStore.labels[activeLabel.value].color
+          : undefined,
+        firstPoint: initState.firstPoint,
+        secondPoint: initState.secondPoint,
+      });
     };
 
-    // --- updating active tool frame --- //
-
-    // TODO useCurrentFrameOfReference(viewDirection)
-    const getCurrentFrameOfReference = (): FrameOfReference => {
-      const { lpsOrientation, indexToWorld } = currentImageMetadata.value;
-      const planeNormal = lpsOrientation[viewDirection.value] as Vector3;
-      const lpsIdx = lpsOrientation[viewAxis.value];
-      const planeOrigin: Vector3 = [0, 0, 0];
-      planeOrigin[lpsIdx] = currentSlice.value;
-      // convert index pt to world pt
-      vec3.transformMat4(planeOrigin, planeOrigin, indexToWorld);
-      return {
-        planeNormal,
-        planeOrigin,
-      };
-    };
-    // update active ruler's frame + slice, since the
-    // active ruler is not finalized.
-    watch(
-      [currentSlice, placingToolID] as const,
-      ([slice, toolID]) => {
-        if (!toolID) return;
-        activeToolStore.updateTool(toolID, {
-          frameOfReference: getCurrentFrameOfReference(),
-          slice,
-        });
-      },
-      { immediate: true }
-    );
+    // --- right-click menu --- //
 
     const { contextMenu, openContextMenu } = useContextMenu();
 
+    // --- //
+
     const currentTools = useCurrentTools(activeToolStore, viewAxis);
+    const activeLabelProps = computed(() => {
+      return activeLabel.value ? activeToolStore.labels[activeLabel.value] : {};
+    });
 
     return {
       tools: currentTools,
-      placingToolID,
+      isToolActive,
       onToolPlaced,
       contextMenu,
       openContextMenu,
       activeToolStore,
+      activeLabelProps,
     };
   },
 });

--- a/src/components/tools/rectangle/common.ts
+++ b/src/components/tools/rectangle/common.ts
@@ -1,0 +1,38 @@
+import { onVTKEvent } from '@/src/composables/onVTKEvent';
+import { Maybe } from '@/src/types';
+import vtkRectangleWidget, {
+  vtkRectangleWidgetState,
+} from '@/src/vtk/RectangleWidget';
+import { Vector3 } from '@kitware/vtk.js/types';
+import { reactive } from 'vue';
+
+export interface RectangleInitState {
+  firstPoint: Vector3;
+  secondPoint: Vector3;
+}
+
+export function useSyncedRectangleState(widgetFactory: vtkRectangleWidget) {
+  const widgetState = widgetFactory.getWidgetState() as vtkRectangleWidgetState;
+  const syncedState = reactive({
+    firstPoint: {
+      visible: false,
+      origin: null as Maybe<Vector3>,
+    },
+    secondPoint: {
+      visible: false,
+      origin: null as Maybe<Vector3>,
+    },
+  });
+
+  const syncState = () => {
+    syncedState.firstPoint.visible = widgetState.getFirstPoint().getVisible();
+    syncedState.firstPoint.origin = widgetState.getFirstPoint().getOrigin();
+    syncedState.secondPoint.visible = widgetState.getSecondPoint().getVisible();
+    syncedState.secondPoint.origin = widgetState.getSecondPoint().getOrigin();
+  };
+
+  onVTKEvent(widgetState, 'onModified', () => syncState());
+  syncState();
+
+  return syncedState;
+}

--- a/src/components/tools/ruler/RulerSVG2D.vue
+++ b/src/components/tools/ruler/RulerSVG2D.vue
@@ -65,6 +65,7 @@ import {
   watch,
   inject,
 } from 'vue';
+import { Maybe } from '@/src/types';
 
 type SVGPoint = {
   x: number;
@@ -73,8 +74,8 @@ type SVGPoint = {
 
 export default defineComponent({
   props: {
-    point1: Array as PropType<Array<number>>,
-    point2: Array as PropType<Array<number>>,
+    point1: Array as PropType<Maybe<Array<number>>>,
+    point2: Array as PropType<Maybe<Array<number>>>,
     color: String,
     length: Number,
     viewId: {

--- a/src/components/tools/ruler/common.ts
+++ b/src/components/tools/ruler/common.ts
@@ -1,0 +1,38 @@
+import { onVTKEvent } from '@/src/composables/onVTKEvent';
+import { Maybe } from '@/src/types';
+import vtkRulerWidget, { vtkRulerWidgetState } from '@/src/vtk/RulerWidget';
+import { Vector3 } from '@kitware/vtk.js/types';
+import { reactive } from 'vue';
+
+export interface RulerInitState {
+  firstPoint: Vector3;
+  secondPoint: Vector3;
+}
+
+export function useSyncedRulerState(widgetFactory: vtkRulerWidget) {
+  const widgetState = widgetFactory.getWidgetState() as vtkRulerWidgetState;
+  const syncedState = reactive({
+    firstPoint: {
+      visible: false,
+      origin: null as Maybe<Vector3>,
+    },
+    secondPoint: {
+      visible: false,
+      origin: null as Maybe<Vector3>,
+    },
+    length: 0,
+  });
+
+  const syncState = () => {
+    syncedState.firstPoint.visible = widgetState.getFirstPoint().getVisible();
+    syncedState.firstPoint.origin = widgetState.getFirstPoint().getOrigin();
+    syncedState.secondPoint.visible = widgetState.getSecondPoint().getVisible();
+    syncedState.secondPoint.origin = widgetState.getSecondPoint().getOrigin();
+    syncedState.length = widgetFactory.getLength();
+  };
+
+  onVTKEvent(widgetState, 'onModified', () => syncState());
+  syncState();
+
+  return syncedState;
+}

--- a/src/composables/annotationTool.ts
+++ b/src/composables/annotationTool.ts
@@ -31,6 +31,7 @@ const useDoesToolFrameMatchViewAxis = <
   return !!toolAxis && toolAxis.axis === viewAxis.value;
 };
 
+// TODO move to viewDirection in case we need to be more specific in the future
 export const useCurrentTools = <ToolID extends string>(
   toolStore: AnnotationToolStore<ToolID>,
   viewAxis: Ref<LPSAxis>

--- a/src/composables/annotationTool.ts
+++ b/src/composables/annotationTool.ts
@@ -3,6 +3,7 @@ import { useCurrentImage } from '@/src/composables/useCurrentImage';
 import { frameOfReferenceToImageSliceAndAxis } from '@/src/utils/frameOfReference';
 import { vtkAnnotationToolWidget } from '@/src/vtk/ToolWidgetUtils/utils';
 import { onVTKEvent } from '@/src/composables/onVTKEvent';
+import { Maybe } from '@/src/types';
 import { LPSAxis } from '../types/lps';
 import { AnnotationTool, ContextMenuEvent } from '../types/annotation-tool';
 import { AnnotationToolStore } from '../store/tools/useAnnotationTool';
@@ -66,7 +67,7 @@ export const useContextMenu = <ToolID extends string>() => {
 
 export const useRightClickContextMenu = (
   emit: (event: 'contextmenu', ...args: any[]) => void,
-  widget: Ref<vtkAnnotationToolWidget | null>
+  widget: Ref<Maybe<vtkAnnotationToolWidget>>
 ) => {
   onVTKEvent(widget, 'onRightClickEvent', (eventData) => {
     const displayXY = getCSSCoordinatesFromEvent(eventData);

--- a/src/composables/useCurrentFrameOfReference.ts
+++ b/src/composables/useCurrentFrameOfReference.ts
@@ -1,0 +1,32 @@
+import { useCurrentImage } from '@/src/composables/useCurrentImage';
+import { LPSAxisDir } from '@/src/types/lps';
+import { FrameOfReference } from '@/src/utils/frameOfReference';
+import { getLPSAxisFromDir } from '@/src/utils/lps';
+import { Vector3 } from '@kitware/vtk.js/types';
+import { vec3 } from 'gl-matrix';
+import { computed, unref } from 'vue';
+import type { ComputedRef, MaybeRef, Ref } from 'vue';
+
+export function useCurrentFrameOfReference(
+  viewDirection: MaybeRef<LPSAxisDir>,
+  currentSlice: Ref<number>
+): ComputedRef<FrameOfReference> {
+  const viewAxis = computed(() => getLPSAxisFromDir(unref(viewDirection)));
+  const { currentImageMetadata } = useCurrentImage();
+
+  return computed(() => {
+    const { lpsOrientation, indexToWorld } = currentImageMetadata.value;
+    const planeNormal = lpsOrientation[unref(viewDirection)] as Vector3;
+
+    const lpsIdx = lpsOrientation[viewAxis.value];
+    const planeOrigin: Vector3 = [0, 0, 0];
+    planeOrigin[lpsIdx] = currentSlice.value;
+    // convert index pt to world pt
+    vec3.transformMat4(planeOrigin, planeOrigin, indexToWorld);
+
+    return {
+      planeNormal,
+      planeOrigin,
+    };
+  });
+}

--- a/src/composables/useViewWidget.ts
+++ b/src/composables/useViewWidget.ts
@@ -1,0 +1,25 @@
+import { Maybe } from '@/src/types';
+import vtkAbstractWidget from '@kitware/vtk.js/Widgets/Core/AbstractWidget';
+import vtkAbstractWidgetFactory from '@kitware/vtk.js/Widgets/Core/AbstractWidgetFactory';
+import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
+import { onMounted, onUnmounted, ref, unref } from 'vue';
+import type { Ref, MaybeRef, UnwrapRef } from 'vue';
+
+export function useViewWidget<T extends vtkAbstractWidget>(
+  factory: vtkAbstractWidgetFactory,
+  widgetManager: MaybeRef<vtkWidgetManager>
+) {
+  const widget = ref<Maybe<T>>(null);
+
+  onMounted(() => {
+    widget.value = unref(widgetManager).addWidget(factory) as UnwrapRef<T>;
+  });
+
+  onUnmounted(() => {
+    if (!widget.value) return;
+    unref(widgetManager).removeWidget(widget.value);
+    widget.value.delete();
+  });
+
+  return widget as Ref<Maybe<T>>;
+}

--- a/src/vtk/PolygonWidget/common.ts
+++ b/src/vtk/PolygonWidget/common.ts
@@ -1,0 +1,2 @@
+export const MoveHandleLabel = 'moveHandle';
+export const HandlesLabel = 'handles';

--- a/src/vtk/PolygonWidget/index.d.ts
+++ b/src/vtk/PolygonWidget/index.d.ts
@@ -5,14 +5,20 @@ import vtkPlaneManipulator from '@kitware/vtk.js/Widgets/Manipulators/PlaneManip
 import vtkWidgetState from '@kitware/vtk.js/Widgets/Core/WidgetState';
 import { usePolygonStore } from '@/src/store/tools/polygons';
 import { vtkAnnotationToolWidget } from '../ToolWidgetUtils/utils';
+import { Vector3 } from '@kitware/vtk.js/types';
 
 export interface vtkPolygonWidgetPointState extends vtkWidgetState {
   getVisible(): boolean;
+  getOrigin(): Vector3 | null;
+  getScale1(): number;
 }
 
 export interface vtkPolygonWidgetState extends vtkWidgetState {
-  getMoveHandle(): any;
+  getHandles(): vtkPolygonWidgetPointState[];
+  getHandleList(): vtkPolygonWidgetPointState[];
+  getMoveHandle(): vtkPolygonWidgetPointState;
   clearHandles(): void;
+  clearHandleList(): void;
   getPlacing(): boolean;
   setPlacing(is: boolean): void;
   getFinishable(): boolean;
@@ -21,11 +27,11 @@ export interface vtkPolygonWidgetState extends vtkWidgetState {
 
 export interface vtkPolygonViewWidget extends vtkAnnotationToolWidget {
   getWidgetState(): vtkPolygonWidgetState;
+  reset(): void;
 }
 
 export interface IPolygonWidgetInitialValues {
-  id: string;
-  store: ReturnType<typeof usePolygonStore>;
+  widgetState?: vtkPolygonWidgetState;
 }
 
 export interface vtkPolygonWidget extends vtkAbstractWidgetFactory {

--- a/src/vtk/PolygonWidget/index.js
+++ b/src/vtk/PolygonWidget/index.js
@@ -4,9 +4,10 @@ import vtkPlanePointManipulator from '@kitware/vtk.js/Widgets/Manipulators/Plane
 import vtkSphereHandleRepresentation from '@kitware/vtk.js/Widgets/Representations/SphereHandleRepresentation';
 import { Behavior } from '@kitware/vtk.js/Widgets/Representations/WidgetRepresentation/Constants';
 import vtkLineGlyphRepresentation from '@/src/vtk/LineGlyphRepresentation';
+import { HandlesLabel, MoveHandleLabel } from '@/src/vtk/PolygonWidget/common';
 
 import widgetBehavior from './behavior';
-import stateGenerator, { HandlesLabel, MoveHandleLabel } from './state';
+import stateGenerator from './standaloneState';
 
 // ----------------------------------------------------------------------------
 // Factory
@@ -50,9 +51,9 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   vtkAbstractWidgetFactory.extend(publicAPI, model, {
-    ...initialValues,
     behavior: widgetBehavior,
     widgetState: stateGenerator(initialValues),
+    ...initialValues,
   });
   macro.get(publicAPI, model, ['manipulator']);
 

--- a/src/vtk/PolygonWidget/standaloneState.js
+++ b/src/vtk/PolygonWidget/standaloneState.js
@@ -1,0 +1,35 @@
+import vtkStateBuilder from '@kitware/vtk.js/Widgets/Core/StateBuilder';
+import { HANDLE_PIXEL_SIZE } from '@/src/vtk/ToolWidgetUtils/common';
+import { HandlesLabel, MoveHandleLabel } from '@/src/vtk/PolygonWidget/common';
+
+export default function createState() {
+  return vtkStateBuilder
+    .createBuilder()
+    .addDynamicMixinState({
+      name: 'handle',
+      labels: [HandlesLabel],
+      mixins: ['visible', 'origin', 'scale1'],
+      initialValues: {
+        visible: true,
+        scale1: HANDLE_PIXEL_SIZE,
+      },
+    })
+    .addStateFromMixin({
+      name: 'moveHandle',
+      labels: [HandlesLabel, MoveHandleLabel],
+      mixins: ['visible', 'origin', 'scale1'],
+      initialValues: {
+        visible: true,
+        scale1: HANDLE_PIXEL_SIZE,
+      },
+    })
+    .addField({
+      name: 'finishable',
+      initialValue: false,
+    })
+    .addField({
+      name: 'placing',
+      initialValue: false,
+    })
+    .build();
+}

--- a/src/vtk/PolygonWidget/storeState.ts
+++ b/src/vtk/PolygonWidget/storeState.ts
@@ -4,12 +4,11 @@ import bounds from '@kitware/vtk.js/Widgets/Core/StateBuilder/boundsMixin';
 import visibleMixin from '@kitware/vtk.js/Widgets/Core/StateBuilder/visibleMixin';
 import scale1Mixin from '@kitware/vtk.js/Widgets/Core/StateBuilder/scale1Mixin';
 import { Vector3 } from '@kitware/vtk.js/types';
+import { NOOP } from '@/src/constants';
+import { HandlesLabel, MoveHandleLabel } from '@/src/vtk/PolygonWidget/common';
 
 import createPointState from '../ToolWidgetUtils/pointState';
 import { watchState } from '../ToolWidgetUtils/utils';
-
-export const MoveHandleLabel = 'moveHandle';
-export const HandlesLabel = 'handles';
 
 const PIXEL_SIZE = 20;
 
@@ -27,7 +26,7 @@ function vtkPolygonWidgetState(publicAPI: any, model: any) {
     id: model.id,
     store: model._store,
     key: 'movePoint',
-    visible: true,
+    visible: false,
   });
   watchState(publicAPI, model.moveHandle, () => publicAPI.modified());
 
@@ -109,10 +108,13 @@ function vtkPolygonWidgetState(publicAPI: any, model: any) {
     }
   };
 
-  publicAPI.getPlacing = () => getTool().placing;
-  publicAPI.setPlacing = (placing: boolean) => {
-    getTool().placing = placing;
-  };
+  // TODO
+  publicAPI.getPlacing = () => false;
+  publicAPI.setPlacing = NOOP;
+
+  // TODO match standaloneState API
+  publicAPI.getHandleList = publicAPI.getHandles;
+  publicAPI.clearHandleList = publicAPI.clearHandles;
 
   // Setup after deserialization
   getTool().points.forEach((point: Vector3) => {

--- a/src/vtk/RectangleWidget/index.d.ts
+++ b/src/vtk/RectangleWidget/index.d.ts
@@ -8,6 +8,7 @@ import vtkRulerWidget, {
   IRulerWidgetInitialValues,
   vtkRulerViewWidget,
   vtkRulerWidgetPointState,
+  vtkRulerWidgetState,
 } from '../RulerWidget';
 
 export { InteractionState } from '../RulerWidget';
@@ -21,7 +22,7 @@ export interface vtkRectangleViewWidget extends vtkRulerViewWidget {}
 
 export interface IRectangleWidgetInitialValues
   extends IRulerWidgetInitialValues {
-  store: ReturnType<typeof useRectangleStore>;
+  widgetState: vtkRectangleWidgetState;
 }
 
 export interface vtkRectangleWidget extends vtkRulerWidget {}

--- a/src/vtk/RectangleWidget/index.js
+++ b/src/vtk/RectangleWidget/index.js
@@ -3,6 +3,7 @@ import macro from '@kitware/vtk.js/macro';
 import vtkRulerWidget from '../RulerWidget';
 
 export { InteractionState } from '../RulerWidget/behavior';
+
 // ----------------------------------------------------------------------------
 // Factory
 // ----------------------------------------------------------------------------
@@ -20,15 +21,7 @@ const DEFAULT_VALUES = {};
 export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
-  const { store: toolStore, ...rest } = initialValues;
-
-  const rulerStore = {
-    ...toolStore,
-    rulerByID: toolStore.toolByID,
-    updateRuler: toolStore.updateTool,
-  };
-
-  vtkRulerWidget.extend(publicAPI, model, { store: rulerStore, ...rest });
+  vtkRulerWidget.extend(publicAPI, model, initialValues);
 
   vtkRectangleWidget(publicAPI, model);
 }

--- a/src/vtk/RulerWidget/behavior.ts
+++ b/src/vtk/RulerWidget/behavior.ts
@@ -55,6 +55,11 @@ export default function widgetBehavior(publicAPI: any, model: any) {
     model._interactor.cancelAnimation(publicAPI, true);
   };
 
+  publicAPI.resetState = () => {
+    model.widgetState.getFirstPoint().setOrigin(null);
+    model.widgetState.getSecondPoint().setOrigin(null);
+  };
+
   /**
    * Places or drags a point.
    */

--- a/src/vtk/RulerWidget/behavior.ts
+++ b/src/vtk/RulerWidget/behavior.ts
@@ -44,7 +44,7 @@ export default function widgetBehavior(publicAPI: any, model: any) {
   publicAPI.setInteractionState = (state: InteractionState) => {
     const changed = originalSetInteractionState(state);
     if (changed && state === InteractionState.PlacingFirst) {
-      model.widgetState.setIsPlaced(false);
+      // model.widgetState.setIsPlaced(false);
       model.widgetState.getFirstPoint().setVisible(false);
       model.widgetState.getSecondPoint().setVisible(false);
     }
@@ -99,7 +99,7 @@ export default function widgetBehavior(publicAPI: any, model: any) {
 
     if (intState === InteractionState.PlacingSecond) {
       publicAPI.setSecondPoint(worldCoords);
-      model.widgetState.setIsPlaced(true);
+      // model.widgetState.setIsPlaced(true);
 
       publicAPI.setInteractionState(InteractionState.Select);
       publicAPI.invokeEndInteractionEvent();

--- a/src/vtk/RulerWidget/index.d.ts
+++ b/src/vtk/RulerWidget/index.d.ts
@@ -6,11 +6,13 @@ import { InteractionState } from './behavior';
 import { useRulerStore } from '@/src/store/tools/rulers';
 import vtkWidgetState from '@kitware/vtk.js/Widgets/Core/WidgetState';
 import { vtkAnnotationToolWidget } from '../ToolWidgetUtils/utils';
+import { Nullable, Vector3 } from '@kitware/vtk.js/types';
 
 export { InteractionState } from './behavior';
 
 export interface vtkRulerWidgetPointState extends vtkWidgetState {
   getVisible(): boolean;
+  getOrigin(): Nullable<Vector3>;
 }
 
 export interface vtkRulerWidgetState extends vtkWidgetState {
@@ -24,12 +26,11 @@ export interface vtkRulerViewWidget extends vtkAnnotationToolWidget {
   setInteractionState(state: InteractionState): boolean;
   getInteractionState(): InteractionState;
   getWidgetState(): vtkRulerWidgetState;
+  resetState(): void;
 }
 
 export interface IRulerWidgetInitialValues {
-  id: string;
-  store: ReturnType<typeof useRulerStore>;
-  isPlaced: boolean;
+  widgetState?: vtkRulerWidgetState;
 }
 
 export interface vtkRulerWidget extends vtkAbstractWidgetFactory {

--- a/src/vtk/RulerWidget/index.js
+++ b/src/vtk/RulerWidget/index.js
@@ -4,8 +4,10 @@ import vtkPlanePointManipulator from '@kitware/vtk.js/Widgets/Manipulators/Plane
 import vtkSphereHandleRepresentation from '@kitware/vtk.js/Widgets/Representations/SphereHandleRepresentation';
 import { distance2BetweenPoints } from '@kitware/vtk.js/Common/Core/Math';
 
+import { POINTS_LABEL } from '@/src/vtk/ToolWidgetUtils/common';
+
 import widgetBehavior from './behavior';
-import stateGenerator, { PointsLabel } from './state';
+import stateGenerator from './standaloneState';
 
 export { InteractionState } from './behavior';
 
@@ -21,7 +23,7 @@ function vtkRulerWidget(publicAPI, model) {
   publicAPI.getRepresentationsForViewType = () => [
     {
       builder: vtkSphereHandleRepresentation,
-      labels: [PointsLabel],
+      labels: [POINTS_LABEL],
       initialValues: {
         scaleInPixels: true,
       },
@@ -51,9 +53,9 @@ export function extend(publicAPI, model, initialValues = {}) {
   Object.assign(model, DEFAULT_VALUES, initialValues);
 
   vtkAbstractWidgetFactory.extend(publicAPI, model, {
-    ...initialValues,
     behavior: widgetBehavior,
     widgetState: stateGenerator(initialValues),
+    ...initialValues,
   });
   macro.get(publicAPI, model, ['manipulator']);
 

--- a/src/vtk/RulerWidget/standaloneState.js
+++ b/src/vtk/RulerWidget/standaloneState.js
@@ -1,0 +1,29 @@
+import vtkStateBuilder from '@kitware/vtk.js/Widgets/Core/StateBuilder';
+import {
+  HANDLE_PIXEL_SIZE,
+  POINTS_LABEL,
+} from '@/src/vtk/ToolWidgetUtils/common';
+
+export default function createState() {
+  return vtkStateBuilder
+    .createBuilder()
+    .addStateFromMixin({
+      name: 'firstPoint',
+      labels: [POINTS_LABEL],
+      mixins: ['visible', 'origin', 'scale1'],
+      initialValues: {
+        visible: false,
+        scale1: HANDLE_PIXEL_SIZE,
+      },
+    })
+    .addStateFromMixin({
+      name: 'secondPoint',
+      labels: [POINTS_LABEL],
+      mixins: ['visible', 'origin', 'scale1'],
+      initialValues: {
+        visible: false,
+        scale1: HANDLE_PIXEL_SIZE,
+      },
+    })
+    .build();
+}

--- a/src/vtk/RulerWidget/storeState.ts
+++ b/src/vtk/RulerWidget/storeState.ts
@@ -2,10 +2,9 @@ import macro from '@kitware/vtk.js/macros';
 import vtkWidgetState from '@kitware/vtk.js/Widgets/Core/WidgetState';
 import bounds from '@kitware/vtk.js/Widgets/Core/StateBuilder/boundsMixin';
 
+import { POINTS_LABEL } from '@/src/vtk/ToolWidgetUtils/common';
 import createPointState from '../ToolWidgetUtils/pointState';
 import { watchState } from '../ToolWidgetUtils/utils';
-
-export const PointsLabel = 'points';
 
 function vtkRulerWidgetState(publicAPI: any, model: any) {
   const firstPoint = createPointState({
@@ -25,7 +24,7 @@ function vtkRulerWidgetState(publicAPI: any, model: any) {
   watchState(publicAPI, secondPoint, () => publicAPI.modified());
 
   model.labels = {
-    [PointsLabel]: [firstPoint, secondPoint],
+    [POINTS_LABEL]: [firstPoint, secondPoint],
   };
 
   publicAPI.getFirstPoint = () => firstPoint;
@@ -33,7 +32,6 @@ function vtkRulerWidgetState(publicAPI: any, model: any) {
 }
 
 const defaultValues = (initialValues: any) => ({
-  isPlaced: false,
   ...initialValues,
 });
 
@@ -47,7 +45,6 @@ function _createRulerWidgetState(
   bounds.extend(publicAPI, model);
 
   macro.get(publicAPI, model, ['id']);
-  macro.setGet(publicAPI, model, ['isPlaced']);
   macro.moveToProtected(publicAPI, model, ['store']);
 
   vtkRulerWidgetState(publicAPI, model);

--- a/src/vtk/ToolWidgetUtils/common.ts
+++ b/src/vtk/ToolWidgetUtils/common.ts
@@ -1,2 +1,3 @@
 export const HANDLE_PIXEL_SIZE = 20;
 export const POINTS_LABEL = 'points';
+export const MOVE_HANDLE_LABEL = 'moveHandle';

--- a/src/vtk/ToolWidgetUtils/common.ts
+++ b/src/vtk/ToolWidgetUtils/common.ts
@@ -1,0 +1,2 @@
+export const HANDLE_PIXEL_SIZE = 20;
+export const POINTS_LABEL = 'points';

--- a/src/vtk/ToolWidgetUtils/pointState.js
+++ b/src/vtk/ToolWidgetUtils/pointState.js
@@ -2,25 +2,8 @@ import macro from '@kitware/vtk.js/macros';
 import vtkWidgetState from '@kitware/vtk.js/Widgets/Core/WidgetState';
 import visibleMixin from '@kitware/vtk.js/Widgets/Core/StateBuilder/visibleMixin';
 import scale1Mixin from '@kitware/vtk.js/Widgets/Core/StateBuilder/scale1Mixin';
-
-const PIXEL_SIZE = 20;
-
-function watchStore(publicAPI, store, getter, cmp) {
-  let cached = getter();
-  const unsubscribe = store.$subscribe(() => {
-    const val = getter();
-    if (cmp ? cmp(cached, val) : cached !== val) {
-      cached = val;
-      publicAPI.modified();
-    }
-  });
-
-  const originalDelete = publicAPI.delete;
-  publicAPI.delete = () => {
-    unsubscribe();
-    originalDelete();
-  };
-}
+import { HANDLE_PIXEL_SIZE } from '@/src/vtk/ToolWidgetUtils/common';
+import { watchStore } from '@/src/vtk/ToolWidgetUtils/utils';
 
 function _createPointState(
   publicAPI,
@@ -34,7 +17,7 @@ function _createPointState(
   });
   vtkWidgetState.extend(publicAPI, model, {});
   visibleMixin.extend(publicAPI, model, { visible });
-  scale1Mixin.extend(publicAPI, model, { scale1: PIXEL_SIZE });
+  scale1Mixin.extend(publicAPI, model, { scale1: HANDLE_PIXEL_SIZE });
 
   const getTool = () => {
     return model._store.toolByID[model.id];

--- a/src/vtk/ToolWidgetUtils/utils.ts
+++ b/src/vtk/ToolWidgetUtils/utils.ts
@@ -1,6 +1,30 @@
+import { Maybe } from '@/src/types';
 import vtkAbstractWidget from '@kitware/vtk.js/Widgets/Core/AbstractWidget';
 import vtkPlaneManipulator from '@kitware/vtk.js/Widgets/Manipulators/PlaneManipulator';
 import { vtkSubscription } from '@kitware/vtk.js/interfaces';
+import { Store } from 'pinia';
+
+export function watchStore<T>(
+  publicAPI: any,
+  store: Store,
+  getter: () => Maybe<T>,
+  cmp: (a: Maybe<T>, b: Maybe<T>) => boolean
+) {
+  let cached = getter();
+  const unsubscribe = store.$subscribe(() => {
+    const val = getter();
+    if (cmp ? cmp(cached, val) : cached !== val) {
+      cached = val;
+      publicAPI.modified();
+    }
+  });
+
+  const originalDelete = publicAPI.delete;
+  publicAPI.delete = () => {
+    unsubscribe();
+    originalDelete();
+  };
+}
 
 export function watchState(
   publicAPI: any,


### PR DESCRIPTION
Architectural changes, using the ruler as an example:
- RulerTool has greatly simplified placing ruler management. RulerTool is now only concerned with using PlacingRulerWidget2D.
- RulerWidget2D no longer mixes placing logic and regular logic. Placing logic is now in PlacingRulerWidget2D.
- vtkRulerWidget state is now split into store-derived state and standalone state. The standalone state holds the state for the placing ruler and is resettable.
- (Placing)RulerWidget2D uses a common synchronized-state interface (`syncedState`), which is a reactive object derived from the widget state (regardless of if it's store-derived or standalone state).

Visual diagram of what these changes achieve:
<img width="397" alt="image" src="https://github.com/Kitware/VolView/assets/1812167/500bdc74-93d2-408b-b63a-79e011f783a6">
