### PR TITLE
Simplify tool code

### DIFF
--- a/src/components/MeasurementsToolList.vue
+++ b/src/components/MeasurementsToolList.vue
@@ -24,10 +24,8 @@ const { currentImageID, currentImageMetadata } = useCurrentImage();
 
 // Filter and add axis for specific annotation type
 const getTools = (toolStore: AnnotationToolStore<string>) => {
-  const byID = toolStore.toolByID;
-  return toolStore.toolIDs
-    .map((id) => byID[id])
-    .filter((tool) => !tool.placing && tool.imageID === currentImageID.value)
+  return toolStore.finishedTools
+    .filter((tool) => tool.imageID === currentImageID.value)
     .map((tool) => {
       const { axis } = frameOfReferenceToImageSliceAndAxis(
         tool.frameOfReference,

--- a/src/components/tools/polygon/PolygonSVG2D.vue
+++ b/src/components/tools/polygon/PolygonSVG2D.vue
@@ -37,6 +37,7 @@ import {
   watch,
   inject,
 } from 'vue';
+import { Maybe } from '@/src/types';
 
 const POINT_RADIUS = ANNOTATION_TOOL_HANDLE_RADIUS;
 const FINISHABLE_POINT_RADIUS = POINT_RADIUS + 6;
@@ -53,7 +54,7 @@ export default defineComponent({
       required: true,
     },
     movePoint: {
-      type: Array as unknown as PropType<Vector3>,
+      type: Array as unknown as PropType<Maybe<Vector3>>,
     },
     placing: {
       type: Boolean,

--- a/src/components/tools/polygon/PolygonTool.vue
+++ b/src/components/tools/polygon/PolygonTool.vue
@@ -32,15 +32,12 @@ import {
   watch,
 } from 'vue';
 import { storeToRefs } from 'pinia';
-import { vec3 } from 'gl-matrix';
 import { useCurrentImage } from '@/src/composables/useCurrentImage';
 import { useToolStore } from '@/src/store/tools';
 import { Tools } from '@/src/store/tools/types';
 import { getLPSAxisFromDir } from '@/src/utils/lps';
 import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
-import type { Vector3 } from '@kitware/vtk.js/types';
 import { LPSAxisDir } from '@/src/types/lps';
-import { FrameOfReference } from '@/src/utils/frameOfReference';
 import { usePolygonStore } from '@/src/store/tools/polygons';
 import { PolygonID } from '@/src/types/polygon';
 import {
@@ -51,6 +48,7 @@ import {
 import AnnotationContextMenu from '@/src/components/tools/AnnotationContextMenu.vue';
 import AnnotationInfo from '@/src/components/tools/AnnotationInfo.vue';
 import BoundingRectangle from '@/src/components/tools/BoundingRectangle.vue';
+import { useFrameOfReference } from '@/src/composables/useFrameOfReference';
 import PolygonWidget2D from './PolygonWidget2D.vue';
 
 type ToolID = PolygonID;
@@ -158,19 +156,12 @@ export default defineComponent({
 
     // --- updating active tool frame --- //
 
-    const getCurrentFrameOfReference = (): FrameOfReference => {
-      const { lpsOrientation, indexToWorld } = currentImageMetadata.value;
-      const planeNormal = lpsOrientation[viewDirection.value] as Vector3;
-      const lpsIdx = lpsOrientation[viewAxis.value];
-      const planeOrigin: Vector3 = [0, 0, 0];
-      planeOrigin[lpsIdx] = currentSlice.value;
-      // convert index pt to world pt
-      vec3.transformMat4(planeOrigin, planeOrigin, indexToWorld);
-      return {
-        planeNormal,
-        planeOrigin,
-      };
-    };
+    const frameOfReference = useFrameOfReference(
+      viewDirection,
+      currentSlice,
+      currentImageMetadata
+    );
+
     // update active tool's frame + slice, since the
     // active tool is not finalized.
     watch(
@@ -178,7 +169,7 @@ export default defineComponent({
       ([slice, toolID]) => {
         if (!toolID) return;
         activeToolStore.updateTool(toolID, {
-          frameOfReference: getCurrentFrameOfReference(),
+          frameOfReference: frameOfReference.value,
           slice,
         });
       },
@@ -213,3 +204,4 @@ export default defineComponent({
 </script>
 
 <style scoped src="@/src/components/styles/vtk-view.css"></style>
+@/src/composables/useFrameOfReference

--- a/src/components/tools/polygon/PolygonTool.vue
+++ b/src/components/tools/polygon/PolygonTool.vue
@@ -163,4 +163,3 @@ export default defineComponent({
 </script>
 
 <style scoped src="@/src/components/styles/vtk-view.css"></style>
-@/src/composables/useFrameOfReference

--- a/src/components/tools/rectangle/RectangleTool.vue
+++ b/src/components/tools/rectangle/RectangleTool.vue
@@ -27,7 +27,6 @@ import {
   defineComponent,
   onUnmounted,
   PropType,
-  ref,
   toRefs,
   watch,
 } from 'vue';
@@ -39,11 +38,11 @@ import { getLPSAxisFromDir } from '@/src/utils/lps';
 import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
 import { LPSAxisDir } from '@/src/types/lps';
 import { useRectangleStore } from '@/src/store/tools/rectangles';
-import { RectangleID } from '@/src/types/rectangle';
 import {
   useCurrentTools,
   useContextMenu,
   useHover,
+  usePlacingAnnotationTool,
 } from '@/src/composables/annotationTool';
 import AnnotationContextMenu from '@/src/components/tools/AnnotationContextMenu.vue';
 import AnnotationInfo from '@/src/components/tools/AnnotationInfo.vue';
@@ -51,7 +50,6 @@ import BoundingRectangle from '@/src/components/tools/BoundingRectangle.vue';
 import { useFrameOfReference } from '@/src/composables/useFrameOfReference';
 import RectangleWidget2D from './RectangleWidget2D.vue';
 
-type ToolID = RectangleID;
 const useActiveToolStore = useRectangleStore;
 const toolType = Tools.Rectangle;
 
@@ -91,70 +89,7 @@ export default defineComponent({
     const isToolActive = computed(() => toolStore.currentTool === toolType);
     const viewAxis = computed(() => getLPSAxisFromDir(viewDirection.value));
 
-    const placingToolID = ref<ToolID | null>(null);
-
     // --- active tool management --- //
-
-    watch(
-      placingToolID,
-      (id, prevId) => {
-        if (prevId != null) {
-          activeToolStore.updateTool(prevId, { placing: false });
-        }
-        if (id != null) {
-          activeToolStore.updateTool(id, { placing: true });
-        }
-      },
-      { immediate: true }
-    );
-
-    watch(
-      [isToolActive, currentImageID] as const,
-      ([active, imageID]) => {
-        if (placingToolID.value != null) {
-          activeToolStore.removeTool(placingToolID.value);
-          placingToolID.value = null;
-        }
-        if (active && imageID) {
-          placingToolID.value = activeToolStore.addTool({
-            imageID,
-            placing: true,
-          });
-        }
-      },
-      { immediate: true }
-    );
-
-    watch(
-      [activeLabel, placingToolID],
-      ([label, placingTool]) => {
-        if (placingTool != null) {
-          activeToolStore.updateTool(placingTool, {
-            label,
-            ...(label && activeToolStore.labels[label]),
-          });
-        }
-      },
-      { immediate: true }
-    );
-
-    onUnmounted(() => {
-      if (placingToolID.value != null) {
-        activeToolStore.removeTool(placingToolID.value);
-        placingToolID.value = null;
-      }
-    });
-
-    const onToolPlaced = () => {
-      if (currentImageID.value) {
-        placingToolID.value = activeToolStore.addTool({
-          imageID: currentImageID.value,
-          placing: true,
-        });
-      }
-    };
-
-    // --- updating active tool frame --- //
 
     const frameOfReference = useFrameOfReference(
       viewDirection,
@@ -162,19 +97,43 @@ export default defineComponent({
       currentImageMetadata
     );
 
-    // update active ruler's frame + slice, since the
-    // active ruler is not finalized.
-    watch(
-      [currentSlice, placingToolID] as const,
-      ([slice, toolID]) => {
-        if (!toolID) return;
-        activeToolStore.updateTool(toolID, {
+    const placingTool = usePlacingAnnotationTool(
+      activeToolStore,
+      computed(() => {
+        if (!currentImageID.value) return {};
+        return {
+          imageID: currentImageID.value,
           frameOfReference: frameOfReference.value,
-          slice,
-        });
+          slice: currentSlice.value,
+          label: activeLabel.value,
+          ...(activeLabel.value && activeToolStore.labels[activeLabel.value]),
+        };
+      })
+    );
+
+    watch(
+      [isToolActive, currentImageID] as const,
+      ([active, imageID]) => {
+        placingTool.remove();
+        if (active && imageID) {
+          placingTool.add();
+        }
       },
       { immediate: true }
     );
+
+    onUnmounted(() => {
+      placingTool.remove();
+    });
+
+    const onToolPlaced = () => {
+      if (currentImageID.value) {
+        placingTool.commit();
+        placingTool.add();
+      }
+    };
+
+    // ---  //
 
     const { contextMenu, openContextMenu } = useContextMenu();
 
@@ -190,7 +149,7 @@ export default defineComponent({
 
     return {
       tools: currentTools,
-      placingToolID,
+      placingToolID: placingTool.id,
       onToolPlaced,
       contextMenu,
       openContextMenu,

--- a/src/components/tools/ruler/RulerWidget2D.vue
+++ b/src/components/tools/ruler/RulerWidget2D.vue
@@ -2,16 +2,15 @@
 import vtkRulerWidget, {
   InteractionState,
   vtkRulerViewWidget,
-  vtkRulerWidgetPointState,
 } from '@/src/vtk/RulerWidget';
 import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
 import {
+  reactive,
   computed,
   defineComponent,
   onMounted,
   onUnmounted,
   PropType,
-  Ref,
   ref,
   toRefs,
   watch,
@@ -24,7 +23,6 @@ import { LPSAxisDir } from '@/src/types/lps';
 import { useRulerStore } from '@/src/store/tools/rulers';
 import { onVTKEvent } from '@/src/composables/onVTKEvent';
 import RulerSVG2D from '@/src/components/tools/ruler/RulerSVG2D.vue';
-import { watchOnce } from '@vueuse/core';
 import {
   useRightClickContextMenu,
   useHoverEvent,
@@ -167,36 +165,24 @@ export default defineComponent({
 
     // --- handle pick visibility --- //
 
-    const usePointVisibility = (
-      pointState: Ref<vtkRulerWidgetPointState | undefined>
-    ) => {
-      const visible = ref(false);
-      const updateVisibility = () => {
-        if (!pointState.value) return;
-        visible.value = pointState.value.getVisible();
-      };
+    const visibleStates = reactive({
+      firstPoint: false,
+      secondPoint: false,
+    });
 
-      onVTKEvent(pointState, 'onModified', () => updateVisibility());
-
-      watchOnce(pointState, () => updateVisibility());
-
-      return visible;
-    };
-
-    const firstPointVisible = usePointVisibility(
-      computed(() => widget.value?.getWidgetState().getFirstPoint())
-    );
-    const secondPointVisible = usePointVisibility(
-      computed(() => widget.value?.getWidgetState().getSecondPoint())
-    );
+    const widgetState = widgetFactory.getWidgetState();
+    onVTKEvent(widgetFactory.getWidgetState(), 'onModified', () => {
+      visibleStates.firstPoint = widgetState.getFirstPoint().getVisible();
+      visibleStates.secondPoint = widgetState.getSecondPoint().getVisible();
+    });
 
     return {
       ruler,
       firstPoint: computed(() => {
-        return firstPointVisible.value ? ruler.value.firstPoint : undefined;
+        return visibleStates.firstPoint ? ruler.value.firstPoint : undefined;
       }),
       secondPoint: computed(() => {
-        return secondPointVisible.value ? ruler.value.secondPoint : undefined;
+        return visibleStates.secondPoint ? ruler.value.secondPoint : undefined;
       }),
       length: computed(() => rulerStore.lengthByID[ruler.value.id]),
     };

--- a/src/components/tools/ruler/RulerWidget2D.vue
+++ b/src/components/tools/ruler/RulerWidget2D.vue
@@ -2,6 +2,7 @@
 import vtkRulerWidget, {
   InteractionState,
   vtkRulerViewWidget,
+  vtkRulerWidgetState,
 } from '@/src/vtk/RulerWidget';
 import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
 import {
@@ -170,11 +171,16 @@ export default defineComponent({
       secondPoint: false,
     });
 
-    const widgetState = widgetFactory.getWidgetState();
-    onVTKEvent(widgetFactory.getWidgetState(), 'onModified', () => {
+    const updateVisibleState = (widgetState: vtkRulerWidgetState) => {
       visibleStates.firstPoint = widgetState.getFirstPoint().getVisible();
       visibleStates.secondPoint = widgetState.getSecondPoint().getVisible();
-    });
+    };
+
+    const widgetState = widgetFactory.getWidgetState();
+    onVTKEvent(widgetFactory.getWidgetState(), 'onModified', () =>
+      updateVisibleState(widgetState)
+    );
+    updateVisibleState(widgetState);
 
     return {
       ruler,

--- a/src/composables/useFrameOfReference.ts
+++ b/src/composables/useFrameOfReference.ts
@@ -1,0 +1,32 @@
+import { ImageMetadata } from '@/src/types/image';
+import { LPSAxisDir } from '@/src/types/lps';
+import { FrameOfReference } from '@/src/utils/frameOfReference';
+import { getLPSAxisFromDir } from '@/src/utils/lps';
+import { Vector3 } from '@kitware/vtk.js/types';
+import { vec3 } from 'gl-matrix';
+import { computed, unref } from 'vue';
+import type { ComputedRef, MaybeRef } from 'vue';
+
+export function useFrameOfReference(
+  viewDirection: MaybeRef<LPSAxisDir>,
+  slice: MaybeRef<number>,
+  imageMetadata: MaybeRef<ImageMetadata>
+): ComputedRef<FrameOfReference> {
+  const viewAxis = computed(() => getLPSAxisFromDir(unref(viewDirection)));
+
+  return computed(() => {
+    const { lpsOrientation, indexToWorld } = unref(imageMetadata);
+    const planeNormal = lpsOrientation[unref(viewDirection)] as Vector3;
+
+    const lpsIdx = lpsOrientation[viewAxis.value];
+    const planeOrigin: Vector3 = [0, 0, 0];
+    planeOrigin[lpsIdx] = unref(slice);
+    // convert index pt to world pt
+    vec3.transformMat4(planeOrigin, planeOrigin, indexToWorld);
+
+    return {
+      planeNormal,
+      planeOrigin,
+    };
+  });
+}

--- a/src/store/tools/polygons.ts
+++ b/src/store/tools/polygons.ts
@@ -7,7 +7,6 @@ import { Manifest, StateFile } from '@/src/io/state-file/schema';
 import { useAnnotationTool } from './useAnnotationTool';
 
 const toolDefaults = () => ({
-  movePoint: [0, 0, 0] as Vector3,
   points: [] as Array<Vector3>,
   id: '' as PolygonID,
   name: 'Polygon',

--- a/src/store/tools/useAnnotationTool.ts
+++ b/src/store/tools/useAnnotationTool.ts
@@ -56,6 +56,10 @@ export const useAnnotationTool = <
     return toolIDs.value.map((id) => byID[id]);
   });
 
+  const finishedTools = computed(() =>
+    tools.value.filter((tool) => !tool.placing)
+  );
+
   const labels = useLabels<LabelProps>(newLabelDefault);
   labels.mergeLabels(initialLabels, false);
 
@@ -197,6 +201,7 @@ export const useAnnotationTool = <
     toolIDs,
     toolByID,
     tools,
+    finishedTools,
     addTool,
     removeTool,
     updateTool,

--- a/src/types/polygon.ts
+++ b/src/types/polygon.ts
@@ -8,5 +8,4 @@ export type Polygon = {
    * Points is in image index space.
    */
   points: Array<Vector3>;
-  movePoint: Vector3;
 } & AnnotationTool<PolygonID>;

--- a/src/vtk/ToolWidgetUtils/pointState.js
+++ b/src/vtk/ToolWidgetUtils/pointState.js
@@ -2,26 +2,10 @@ import macro from '@kitware/vtk.js/macros';
 import vtkWidgetState from '@kitware/vtk.js/Widgets/Core/WidgetState';
 import visibleMixin from '@kitware/vtk.js/Widgets/Core/StateBuilder/visibleMixin';
 import scale1Mixin from '@kitware/vtk.js/Widgets/Core/StateBuilder/scale1Mixin';
+import { watchStore } from '@/src/vtk/ToolWidgetUtils/utils';
 import { ANNOTATION_TOOL_HANDLE_RADIUS } from '@/src/constants';
 
 const PIXEL_SIZE = ANNOTATION_TOOL_HANDLE_RADIUS * 2;
-
-function watchStore(publicAPI, store, getter, cmp) {
-  let cached = getter();
-  const unsubscribe = store.$subscribe(() => {
-    const val = getter();
-    if (cmp ? cmp(cached, val) : cached !== val) {
-      cached = val;
-      publicAPI.modified();
-    }
-  });
-
-  const originalDelete = publicAPI.delete;
-  publicAPI.delete = () => {
-    unsubscribe();
-    originalDelete();
-  };
-}
 
 function _createPointState(
   publicAPI,

--- a/src/vtk/ToolWidgetUtils/utils.ts
+++ b/src/vtk/ToolWidgetUtils/utils.ts
@@ -1,6 +1,30 @@
+import { Maybe } from '@/src/types';
 import vtkAbstractWidget from '@kitware/vtk.js/Widgets/Core/AbstractWidget';
 import vtkPlaneManipulator from '@kitware/vtk.js/Widgets/Manipulators/PlaneManipulator';
 import { vtkSubscription } from '@kitware/vtk.js/interfaces';
+import { Store } from 'pinia';
+
+export function watchStore<T>(
+  publicAPI: any,
+  store: Store,
+  getter: () => Maybe<T>,
+  cmp: (a: Maybe<T>, b: Maybe<T>) => boolean
+) {
+  let cached = getter();
+  const unsubscribe = store.$subscribe(() => {
+    const val = getter();
+    if (cmp ? cmp(cached, val) : cached !== val) {
+      cached = val;
+      publicAPI.modified();
+    }
+  });
+
+  const originalDelete = publicAPI.delete;
+  publicAPI.delete = () => {
+    unsubscribe();
+    originalDelete();
+  };
+}
 
 export function watchState(
   publicAPI: any,


### PR DESCRIPTION
- Some code refactoring for easier usage
- useFrameOfReference encapsulates the frame of reference handling
- usePlacingAnnotationTool provides a more readable API for managing the placing tool
- added finishedTools to all annotation tools
- simplified the point visibility code to make it more obvious as to what it's doing
- removed the movePoint state from the polygon store