### PR TITLE
Fix widgets not rendering after relayout

### DIFF
--- a/src/components/tools/polygon/PolygonWidget2D.vue
+++ b/src/components/tools/polygon/PolygonWidget2D.vue
@@ -21,6 +21,7 @@ import { onVTKEvent } from '@/src/composables/onVTKEvent';
 import {
   useHoverEvent,
   useRightClickContextMenu,
+  useWidgetVisibility,
 } from '@/src/composables/annotationTool';
 import { usePolygonStore as useStore } from '@/src/store/tools/polygons';
 import { PolygonID as ToolID } from '@/src/types/polygon';
@@ -66,6 +67,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const {
       toolId: stringToolId,
+      viewId,
       widgetManager,
       viewDirection,
       currentSlice,
@@ -137,24 +139,8 @@ export default defineComponent({
 
     // --- visibility --- //
 
-    // toggles the pickability of the tool handles,
-    // since the 3D tool parts are visually hidden.
-    watch(
-      () => !!widget.value && tool.value?.slice === currentSlice.value,
-      (visible) => {
-        widget.value?.setVisibility(visible);
-      },
-      { immediate: true }
-    );
-
-    onMounted(() => {
-      if (!widget.value) {
-        return;
-      }
-      // hide handle visibility, but not picking visibility
-      widget.value.setHandleVisibility(false);
-      widgetManager.value.renderWidgets();
-    });
+    const isVisible = computed(() => tool.value?.slice === currentSlice.value);
+    useWidgetVisibility(widget, isVisible, widgetManager, viewId);
 
     // --- //
 

--- a/src/components/tools/polygon/PolygonWidget2D.vue
+++ b/src/components/tools/polygon/PolygonWidget2D.vue
@@ -4,8 +4,6 @@ import {
   reactive,
   computed,
   defineComponent,
-  onMounted,
-  onUnmounted,
   PropType,
   ref,
   toRefs,
@@ -29,6 +27,11 @@ import vtkWidgetFactory, {
 } from '@/src/vtk/PolygonWidget';
 import { Maybe } from '@/src/types';
 import { Vector3 } from '@kitware/vtk.js/types';
+import { useViewStore } from '@/src/store/views';
+import {
+  useViewProxyMounted,
+  useViewProxyUnmounted,
+} from '@/src/composables/useViewProxy';
 import SVG2DComponent from './PolygonSVG2D.vue';
 
 export default defineComponent({
@@ -76,6 +79,9 @@ export default defineComponent({
     const toolStore = useStore();
     const tool = computed(() => toolStore.toolByID[toolId.value]);
     const { currentImageID, currentImageMetadata } = useCurrentImage();
+    const viewProxy = computed(
+      () => useViewStore().getViewProxy(viewId.value)!
+    );
 
     const widgetFactory = vtkWidgetFactory.newInstance({
       id: toolId.value,
@@ -83,11 +89,11 @@ export default defineComponent({
     });
     const widget = ref<WidgetView | null>(null);
 
-    onMounted(() => {
+    useViewProxyMounted(viewProxy, () => {
       widget.value = widgetManager.value.addWidget(widgetFactory) as WidgetView;
     });
 
-    onUnmounted(() => {
+    useViewProxyUnmounted(viewProxy, () => {
       if (!widget.value) {
         return;
       }
@@ -119,7 +125,7 @@ export default defineComponent({
 
     const manipulator = vtkPlaneManipulator.newInstance();
 
-    onMounted(() => {
+    useViewProxyMounted(viewProxy, () => {
       if (!widget.value) {
         return;
       }

--- a/src/components/tools/polygon/PolygonWidget2D.vue
+++ b/src/components/tools/polygon/PolygonWidget2D.vue
@@ -7,7 +7,6 @@ import {
   onMounted,
   onUnmounted,
   PropType,
-  Ref,
   ref,
   toRefs,
   watch,
@@ -37,7 +36,7 @@ export default defineComponent({
   emits: ['placed', 'contextmenu', 'widgetHover'],
   props: {
     toolId: {
-      type: String,
+      type: String as unknown as PropType<ToolID>,
       required: true,
     },
     widgetManager: {
@@ -66,14 +65,13 @@ export default defineComponent({
   },
   setup(props, { emit }) {
     const {
-      toolId: stringToolId,
+      toolId,
       viewId,
       widgetManager,
       viewDirection,
       currentSlice,
       isPlacing,
     } = toRefs(props);
-    const toolId = ref(stringToolId.value) as Ref<ToolID>;
 
     const toolStore = useStore();
     const tool = computed(() => toolStore.toolByID[toolId.value]);

--- a/src/components/tools/rectangle/RectangleWidget2D.vue
+++ b/src/components/tools/rectangle/RectangleWidget2D.vue
@@ -3,8 +3,6 @@ import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
 import {
   computed,
   defineComponent,
-  onMounted,
-  onUnmounted,
   PropType,
   ref,
   toRefs,
@@ -30,6 +28,11 @@ import {
   useWidgetVisibility,
 } from '@/src/composables/annotationTool';
 import { vtkRulerWidgetState } from '@/src/vtk/RulerWidget';
+import { useViewStore } from '@/src/store/views';
+import {
+  useViewProxyMounted,
+  useViewProxyUnmounted,
+} from '@/src/composables/useViewProxy';
 
 const useStore = useRectangleStore;
 const vtkWidgetFactory = vtkRectangleWidget;
@@ -82,6 +85,9 @@ export default defineComponent({
     const toolStore = useStore();
     const tool = computed(() => toolStore.toolByID[toolId.value]);
     const { currentImageID, currentImageMetadata } = useCurrentImage();
+    const viewProxy = computed(
+      () => useViewStore().getViewProxy(viewId.value)!
+    );
 
     const widgetFactory = vtkWidgetFactory.newInstance({
       id: toolId.value,
@@ -90,11 +96,11 @@ export default defineComponent({
     });
     const widget = ref<WidgetView | null>(null);
 
-    onMounted(() => {
+    useViewProxyMounted(viewProxy, () => {
       widget.value = widgetManager.value.addWidget(widgetFactory) as WidgetView;
     });
 
-    onUnmounted(() => {
+    useViewProxyUnmounted(viewProxy, () => {
       if (!widget.value) {
         return;
       }
@@ -137,7 +143,7 @@ export default defineComponent({
 
     const manipulator = vtkPlaneManipulator.newInstance();
 
-    onMounted(() => {
+    useViewProxyMounted(viewProxy, () => {
       if (!widget.value) {
         return;
       }

--- a/src/components/tools/rectangle/RectangleWidget2D.vue
+++ b/src/components/tools/rectangle/RectangleWidget2D.vue
@@ -6,7 +6,6 @@ import {
   onMounted,
   onUnmounted,
   PropType,
-  Ref,
   ref,
   toRefs,
   watch,
@@ -43,7 +42,7 @@ export default defineComponent({
   emits: ['placed', 'contextmenu', 'widgetHover'],
   props: {
     toolId: {
-      type: String,
+      type: String as unknown as PropType<ToolID>,
       required: true,
     },
     widgetManager: {
@@ -72,14 +71,13 @@ export default defineComponent({
   },
   setup(props, { emit }) {
     const {
-      toolId: stringToolId,
+      toolId,
       viewId,
       widgetManager,
       viewDirection,
       currentSlice,
       isPlacing,
     } = toRefs(props);
-    const toolId = ref(stringToolId.value) as Ref<ToolID>;
 
     const toolStore = useStore();
     const tool = computed(() => toolStore.toolByID[toolId.value]);

--- a/src/components/tools/rectangle/RectangleWidget2D.vue
+++ b/src/components/tools/rectangle/RectangleWidget2D.vue
@@ -28,6 +28,7 @@ import { RectangleID } from '@/src/types/rectangle';
 import {
   useRightClickContextMenu,
   useHoverEvent,
+  useWidgetVisibility,
 } from '@/src/composables/annotationTool';
 import { vtkRulerWidgetState } from '@/src/vtk/RulerWidget';
 
@@ -72,6 +73,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const {
       toolId: stringToolId,
+      viewId,
       widgetManager,
       viewDirection,
       currentSlice,
@@ -155,24 +157,8 @@ export default defineComponent({
 
     // --- visibility --- //
 
-    // toggles the pickability of the tool handles,
-    // since the 3D tool parts are visually hidden.
-    watch(
-      () => !!widget.value && tool.value?.slice === currentSlice.value,
-      (visible) => {
-        widget.value?.setVisibility(visible);
-      },
-      { immediate: true }
-    );
-
-    onMounted(() => {
-      if (!widget.value) {
-        return;
-      }
-      // hide handle visibility, but not picking visibility
-      widget.value.setHandleVisibility(false);
-      widgetManager.value.renderWidgets();
-    });
+    const isVisible = computed(() => tool.value?.slice === currentSlice.value);
+    useWidgetVisibility(widget, isVisible, widgetManager, viewId);
 
     // --- handle pick visibility --- //
 

--- a/src/components/tools/ruler/RulerWidget2D.vue
+++ b/src/components/tools/ruler/RulerWidget2D.vue
@@ -9,8 +9,6 @@ import {
   reactive,
   computed,
   defineComponent,
-  onMounted,
-  onUnmounted,
   PropType,
   ref,
   toRefs,
@@ -29,6 +27,11 @@ import {
   useHoverEvent,
   useWidgetVisibility,
 } from '@/src/composables/annotationTool';
+import { useViewStore } from '@/src/store/views';
+import {
+  useViewProxyMounted,
+  useViewProxyUnmounted,
+} from '@/src/composables/useViewProxy';
 
 export default defineComponent({
   name: 'RulerWidget2D',
@@ -75,6 +78,9 @@ export default defineComponent({
     const rulerStore = useRulerStore();
     const ruler = computed(() => rulerStore.rulerByID[rulerId.value]);
     const { currentImageID, currentImageMetadata } = useCurrentImage();
+    const viewProxy = computed(
+      () => useViewStore().getViewProxy(viewId.value)!
+    );
 
     const widgetFactory = vtkRulerWidget.newInstance({
       id: rulerId.value,
@@ -83,13 +89,13 @@ export default defineComponent({
     });
     const widget = ref<vtkRulerViewWidget | null>(null);
 
-    onMounted(() => {
+    useViewProxyMounted(viewProxy, () => {
       widget.value = widgetManager.value.addWidget(
         widgetFactory
       ) as vtkRulerViewWidget;
     });
 
-    onUnmounted(() => {
+    useViewProxyUnmounted(viewProxy, () => {
       if (!widget.value) {
         return;
       }
@@ -134,7 +140,7 @@ export default defineComponent({
 
     const manipulator = vtkPlaneManipulator.newInstance();
 
-    onMounted(() => {
+    useViewProxyMounted(viewProxy, () => {
       if (!widget.value) {
         return;
       }

--- a/src/components/tools/ruler/RulerWidget2D.vue
+++ b/src/components/tools/ruler/RulerWidget2D.vue
@@ -27,6 +27,7 @@ import RulerSVG2D from '@/src/components/tools/ruler/RulerSVG2D.vue';
 import {
   useRightClickContextMenu,
   useHoverEvent,
+  useWidgetVisibility,
 } from '@/src/composables/annotationTool';
 
 export default defineComponent({
@@ -62,8 +63,14 @@ export default defineComponent({
     RulerSVG2D,
   },
   setup(props, { emit }) {
-    const { rulerId, widgetManager, viewDirection, currentSlice, isPlacing } =
-      toRefs(props);
+    const {
+      rulerId,
+      viewId,
+      widgetManager,
+      viewDirection,
+      currentSlice,
+      isPlacing,
+    } = toRefs(props);
 
     const rulerStore = useRulerStore();
     const ruler = computed(() => rulerStore.rulerByID[rulerId.value]);
@@ -145,24 +152,8 @@ export default defineComponent({
 
     // --- visibility --- //
 
-    // toggles the pickability of the ruler handles,
-    // since the 3D ruler parts are visually hidden.
-    watch(
-      () => !!widget.value && ruler.value?.slice === currentSlice.value,
-      (visible) => {
-        widget.value?.setVisibility(visible);
-      },
-      { immediate: true }
-    );
-
-    onMounted(() => {
-      if (!widget.value) {
-        return;
-      }
-      // hide handle visibility, but not picking visibility
-      widget.value.setHandleVisibility(false);
-      widgetManager.value.renderWidgets();
-    });
+    const isVisible = computed(() => ruler.value?.slice === currentSlice.value);
+    useWidgetVisibility(widget, isVisible, widgetManager, viewId);
 
     // --- handle pick visibility --- //
 

--- a/src/composables/annotationTool.ts
+++ b/src/composables/annotationTool.ts
@@ -1,4 +1,4 @@
-import { Ref, UnwrapRef, computed, onMounted, readonly, ref, watch } from 'vue';
+import { Ref, UnwrapRef, computed, readonly, ref, watch } from 'vue';
 import { Vector2 } from '@kitware/vtk.js/types';
 import { useCurrentImage } from '@/src/composables/useCurrentImage';
 import { frameOfReferenceToImageSliceAndAxis } from '@/src/utils/frameOfReference';
@@ -15,6 +15,7 @@ import vtkAbstractWidget from '@kitware/vtk.js/Widgets/Core/AbstractWidget';
 import { useViewStore } from '@/src/store/views';
 import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
 import { usePopperState } from '@/src/composables/usePopperState';
+import { useViewProxyMounted } from '@/src/composables/useViewProxy';
 
 const SHOW_OVERLAY_DELAY = 250; // milliseconds
 
@@ -246,9 +247,9 @@ export const useWidgetVisibility = <T extends vtkAbstractWidget>(
     { immediate: true }
   );
 
-  const viewProxy = computed(() => useViewStore().getViewProxy(viewId.value));
+  const viewProxy = computed(() => useViewStore().getViewProxy(viewId.value)!);
 
-  onMounted(() => {
+  useViewProxyMounted(viewProxy, () => {
     if (!widget.value) {
       return;
     }


### PR DESCRIPTION
Fixes #424. The views weren't requesting a render after layout changes. I also created a `useWidgetVisibility` composable to encapsulate this behavior.

I also cleaned up toolId prop usage by directly using the prop and typing the toolId to be `PropType<ToolID>`.