### PR TITLE
feat(WebXR): Add initial support for WebXR viewing with VTK.js

### DIFF
--- a/src/components/RenderingModule.vue
+++ b/src/components/RenderingModule.vue
@@ -4,10 +4,11 @@ import { useCurrentImage } from '../composables/useCurrentImage';
 import VolumeProperties from './VolumeProperties.vue';
 import VolumeRendering from './VolumeRendering.vue';
 import VolumePresets from './VolumePresets.vue';
+import WebXRRendering from './WebXRRendering.vue';
 import LayerList from './LayerList.vue';
 
 export default defineComponent({
-  components: { VolumeRendering, VolumePresets, VolumeProperties, LayerList },
+  components: { VolumeRendering, VolumePresets, VolumeProperties, WebXRRendering, LayerList },
   setup() {
     const { currentImageData } = useCurrentImage();
     const hasCurrentImage = computed(() => !!currentImageData.value);
@@ -31,6 +32,7 @@ export default defineComponent({
     <template v-if="hasCurrentImage">
       <volume-rendering />
       <v-expansion-panels v-model="panels" multiple variant="accordion">
+
         <v-expansion-panel value="preset">
           <v-expansion-panel-title>
             <v-icon class="flex-grow-0 mr-4">mdi-palette</v-icon>
@@ -60,6 +62,17 @@ export default defineComponent({
             <layer-list />
           </v-expansion-panel-text>
         </v-expansion-panel>
+        
+        <v-expansion-panel value="webxr">
+          <v-expansion-panel-title>
+            <v-icon class="flex-grow-0 mr-4">mdi-palette</v-icon>
+            WebXR Rendering
+          </v-expansion-panel-title>
+          <v-expansion-panel-text>
+            <web-x-r-rendering />
+          </v-expansion-panel-text>
+        </v-expansion-panel>
+        
       </v-expansion-panels>
     </template>
     <template v-else>

--- a/src/components/WebXRRendering.vue
+++ b/src/components/WebXRRendering.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+import {
+  ref,
+} from 'vue';
+
+import { XrSessionTypes } from '@kitware/vtk.js/Rendering/WebXR/RenderWindowHelper/Constants.js';
+import { onVTKEvent } from '@/src/composables/onVTKEvent';
+import { useViewProxy } from '../composables/useViewProxy';
+import useVTKWebXRStore from '../store/view-configs/webxr';
+import { ViewProxyType } from '../core/proxies';
+import { InitViewIDs } from '../config';
+
+const TARGET_VIEW_ID = InitViewIDs.Three;
+const vtkWebXRStore = useVTKWebXRStore();
+
+const xrSessionRunning = ref(vtkWebXRStore.isXrSessionRunning());
+    
+const namedXrSessionTypes = [
+  { value: 0, title: 'VR Headset'},
+  { value: 1, title: 'AR Mobile Device'},
+  { value: 2, title: 'Holographic Display'},
+  { value: 3, title: 'AR Headset'},
+];
+
+function updateXRStateFunc() {
+  xrSessionRunning.value = !!vtkWebXRStore.xrHelper.getXrSession();
+};
+
+function startXRFunc(sessionType:XrSessionTypes) {
+  const { viewProxy } = useViewProxy(TARGET_VIEW_ID, ViewProxyType.Volume);
+  vtkWebXRStore.xrHelper.setRenderWindow(viewProxy.value.getOpenGLRenderWindow());
+  vtkWebXRStore.xrHelper.startXR(sessionType);
+}
+
+onVTKEvent(vtkWebXRStore.xrHelper, 'onModified', updateXRStateFunc);
+
+function onSendToXRClick() {
+  if(vtkWebXRStore.xrHelper.getXrSession() !== null) {
+    throw new Error('Cannot send to XR: session already running');
+  }
+  if(vtkWebXRStore.selectedXrSessionType === null) {
+    throw new Error('Cannot send to XR: no session type selected');
+  }
+
+  const xrSessionType = vtkWebXRStore.selectedXrSessionType ? vtkWebXRStore.selectedXrSessionType.value : 0;
+
+  if(xrSessionType === XrSessionTypes.LookingGlassVR) {
+    // The Looking Glass WebXR Polyfill overrides support for other XR sessions.
+    vtkWebXRStore.isXrSessionTypeLocked = true;
+
+    // Import the Looking Glass WebXR Polyfill override.
+    // Assumes that the Looking Glass Bridge native application is already running.
+    // See https://docs.lookingglassfactory.com/developer-tools/webxr
+    import(
+      // @ts-expect-error TS2307
+      // eslint-disable-next-line import/no-unresolved, import/extensions
+      /* webpackIgnore: true */ 'https://unpkg.com/@lookingglass/webxr@0.4.0/dist/bundle/webxr.js'
+    ).then((obj) => {
+      // eslint-disable-next-line no-new
+      new obj.LookingGlassWebXRPolyfill();
+
+      // There is a delay between when the Looking Glass polyfill starts and when
+      // the Looking Glass Bridge application finishes populating device information.
+      // Attempting to start the XR session in the intermediate period can result in
+      // undefined behavior such as a failure to start the session or an attempt to start
+      // a standard VR HMD session.
+      // A timeout of 1 second is used to account for this delay as a workaround.
+      // In the future we may explore handling an event notification from the Looking Glass polyfill
+      // when a new Looking Glass device is ready for WebXR rendering.
+      setTimeout(() => startXRFunc(xrSessionType), 1000);
+    });
+  } else if((navigator as any).xr === undefined) {
+    import(
+    // @ts-expect-error TS2307
+    // eslint-disable-next-line import/no-unresolved, import/extensions
+    /* webpackIgnore: true */ 'https://cdn.jsdelivr.net/npm/webxr-polyfill@latest/build/webxr-polyfill.js'
+    ).then(() => {
+      startXRFunc(xrSessionType);
+    })
+  } else {
+    startXRFunc(xrSessionType);
+  }
+};
+
+function onReturnFromXRClick() {
+  if(vtkWebXRStore.xrHelper.getXrSession() === null) {
+    throw new Error('Cannot return from XR: no session running');
+  }
+  vtkWebXRStore.xrHelper.stopXR();
+};
+
+</script>
+
+<template>
+  <div class="mx-2">
+    <v-combobox
+    v-model="vtkWebXRStore.selectedXrSessionType"
+    :items="namedXrSessionTypes"
+    label="Mixed Reality Session Type"
+    item-text="title"
+    item-value="value"
+    :disabled="vtkWebXRStore.isXrSessionTypeLocked"
+    />
+    <button v-if="!xrSessionRunning && vtkWebXRStore.selectedXrSessionType" @click="onSendToXRClick">
+      Send to {{ vtkWebXRStore.selectedXrSessionType.title }}
+    </button>
+    <button v-if="xrSessionRunning" @click="onReturnFromXRClick">Return from XR</button>
+  </div>
+</template>

--- a/src/store/view-configs/webxr.ts
+++ b/src/store/view-configs/webxr.ts
@@ -1,0 +1,22 @@
+import { defineStore } from 'pinia';
+import { ref, Ref } from 'vue';
+import vtkWebXRRenderWindowHelper from '@kitware/vtk.js/Rendering/WebXR/RenderWindowHelper';
+
+export const useVTKWebXRStore = defineStore('vtkWebXR', () => {
+    const xrHelper = vtkWebXRRenderWindowHelper.newInstance();
+    const selectedXrSessionType : Ref<{title: string, value: number} | null> = ref(null);
+    const isXrSessionTypeLocked = ref(false);
+
+    function isXrSessionRunning() : Boolean {
+        return !!xrHelper.getXrSession();
+    }
+
+  return {
+    xrHelper,
+    selectedXrSessionType,
+    isXrSessionTypeLocked,
+    isXrSessionRunning
+  };
+});
+
+export default useVTKWebXRStore;


### PR DESCRIPTION
Adds initial support for viewing VolView scene in WebXR on the local device. Note that performance may vary widely across devices.

Depends on updates to VTK.js WebXR rendering structures in https://github.com/Kitware/vtk-js/pull/2924 .

Opening as a draft PR for discussion and feedback. Note that rendering performance may vary highly across platforms. We may want to explore optimization improvements for VTK.js WebXR rendering and/or disable some XR platform options in VolView for the initial merge.

Many thanks to @PaulHax and @floryst for helping me with VolView development 🚀 

![IMG-8702](https://github.com/Kitware/VolView/assets/40648863/4f8a1cb7-4274-4c19-812f-0d1ac6435ba3)

Suggested remaining TODOs:
- [ ] Explore removing the Looking Glass overlay. May require contributing a config flag to the Looking Glass WebXR polyfill.
- [ ] Test tethered VR rendering
- [ ] Test mobile VR/AR rendering
- [ ] Disable XR options with inadequate performance for now