### PR TITLE
doc(contributing): Update CONTRIBUTING.md for VTK.js development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,3 +44,29 @@ npm run test:e2e:chrome
 When running end-to-end tests, baseline images are saved to `tests/baseline`. Baseline diffs and actual snapshots are saved to `.tmp`.
 
 When adding a new baseline image and test, the image should be pulled from GitHub Actions. Every test run will upload artifacts containing the snapshots taken, and those should be used when verifying and committing the baseline images.
+
+## Developing with VTK.js
+
+Follow these steps to develop against a custom development branch of VTK.js:
+
+1. Build and package VTK.js:
+```sh
+path/to/vtk-js > npm run build:esm
+```
+
+2. Create a symbolic link to the VTK.js distribution folder on your local system:
+```sh
+> cd path/to/vtk-js/dist/esm
+path/to/vtk-js/dist/esm > npm link
+```
+
+3. Reference the symbolic link in your local VolView build:
+```sh
+> cd path/to/VolView
+path/to/VolView > npm link --no-save @kitware/vtk.js
+```
+
+4. Build and run VolView:
+```sh
+path/to/VolView > npm run dev
+```


### PR DESCRIPTION
Adds documentation to `CONTRIBUTING.md` with instructions on how to use a local development branch of VTK.js in a local VolView development build.

Also resolves observed type import error when developing against a local VTK.js development branch:

```sh
 ERROR  Error: The following dependencies are imported but could not be resolved:                             16:46:24

  @kitware/vtk.js/types (imported by C:/repos/VolView/src/components/tools/polygon/PolygonWidget2D.vue?id=0)

Are they installed?
    at file:///C:/repos/VolView/node_modules/vite/dist/node/chunks/dep-df561101.js:45705:23
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async file:///C:/repos/VolView/node_modules/vite/dist/node/chunks/dep-df561101.js:45114:38
```