### PR TITLE
feat(coloring): support config defaults

### DIFF
--- a/src/components/SampleDataBrowser.vue
+++ b/src/components/SampleDataBrowser.vue
@@ -7,6 +7,7 @@ import {
   importDataSources,
 } from '@/src/io/import/importDataSources';
 import { remoteFileToDataSource } from '@/src/io/import/dataSource';
+import useVolumeColoringStore from '@/src/store/view-configs/volume-coloring';
 import { SAMPLE_DATA } from '../config';
 import { useMessageStore } from '../store/messages';
 import { SampleDataset } from '../types';
@@ -105,6 +106,12 @@ export default defineComponent({
             selection.type === 'image' ? selection.dataID : selection.volumeKey;
           loaded.idToURL[id] = sample.url;
           loaded.urlToID[sample.url] = id;
+
+          useVolumeColoringStore().setDefaults(id, {
+            transferFunction: {
+              preset: sample.defaults?.colorPreset,
+            },
+          });
         }
         datasetStore.setPrimarySelection(selection);
       } catch (error) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -168,6 +168,9 @@ export const SAMPLE_DATA: SampleDataset[] = [
       '3D ultrasound of a baby. Downloaded from tomovision.com.(8 MB)',
     url: 'https://data.kitware.com/api/v1/item/635679c311dab8142820a4f4/download',
     image: USFetusThumbnail,
+    defaults: {
+      colorPreset: 'US-Fetal',
+    },
   },
 ];
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -15,6 +15,9 @@ export type SampleDataset = {
   description: string;
   url: string;
   image: string;
+  defaults?: {
+    colorPreset?: string;
+  };
 };
 
 export type RequiredWithPartial<T, K extends keyof T> = Required<Omit<T, K>> &
@@ -48,3 +51,9 @@ export type TypedArrayConstructorName =
   | 'Int32Array'
   | 'Float32Array'
   | 'Float64Array';
+
+export type DeepPartial<T> = T extends object
+  ? {
+      [P in keyof T]?: DeepPartial<T[P]>;
+    }
+  : T;


### PR DESCRIPTION
Adds support for setting volume-coloring defaults. This same API should exist for the other view-config stores eventually.

Sets the default color preset for the fetal sample dataset to US-Fetal.

Fixes #371 