### PR TITLE
fix(VtkTwoView): layer opacity has uniform 1 opacity transfer function 

### DIFF
--- a/src/components/VtkTwoView.vue
+++ b/src/components/VtkTwoView.vue
@@ -203,7 +203,7 @@ import BoundingRectangle from '@/src/components/tools/BoundingRectangle.vue';
 import { useToolSelectionStore } from '@/src/store/tools/toolSelection';
 import { useAnnotationToolStore } from '@/src/store/tools';
 import { doesToolFrameMatchViewAxis } from '@/src/composables/annotationTool';
-import { TypedArray } from '@kitware/vtk.js/types';
+import type { TypedArray } from '@kitware/vtk.js/types';
 import { useResizeObserver } from '../composables/useResizeObserver';
 import { useOrientationLabels } from '../composables/useOrientationLabels';
 import { getLPSAxisFromDir } from '../utils/lps';

--- a/src/store/view-configs/layers.ts
+++ b/src/store/view-configs/layers.ts
@@ -49,6 +49,7 @@ export const defaultLayersConfig = (): LayersConfig => ({
     preset: '',
     mappingRange: [0, 1],
   },
+  // opacity function not used in VtkTwoView
   opacityFunction: {
     mode: vtkPiecewiseFunctionProxy.Mode.Gaussians,
     gaussians: [],


### PR DESCRIPTION
Removes voxel intensity based opacity transfer for layer slices.  All layer voxels have opacity transfer function Y value of 1.  Layer opacity controled by slice mesh opacity.

Good CT-PT dataset for testing https://demo.orthanc-server.com/app/explorer.html#study?uuid=6b9e19d9-62094390-5f9ddb01-4a191ae7-9766b715
    

Closes #355 