### PR TITLE
fix(LayerProperties): handle long layer names

### DIFF
--- a/src/components/LayerList.vue
+++ b/src/components/LayerList.vue
@@ -21,7 +21,12 @@ export default defineComponent({
 
 <template>
   <div class="mx-2">
-    <layer-properties v-for="layer in layers" :key="layer.id" :layer="layer">
+    <layer-properties
+      v-for="layer in layers"
+      :key="layer.id"
+      :layer="layer"
+      class="py-4"
+    >
     </layer-properties>
   </div>
 </template>

--- a/src/components/PatientStudyVolumeBrowser.vue
+++ b/src/components/PatientStudyVolumeBrowser.vue
@@ -3,7 +3,7 @@ import { computed, defineComponent, reactive, toRefs, watch } from 'vue';
 import { Image } from 'itk-wasm';
 import type { PropType } from 'vue';
 import GroupableItem from '@/src/components/GroupableItem.vue';
-import { useDICOMStore } from '../store/datasets-dicom';
+import { getDisplayName, useDICOMStore } from '../store/datasets-dicom';
 import {
   DataSelection,
   DICOMSelection,
@@ -104,6 +104,7 @@ export default defineComponent({
           // for thumbnailing
           cacheKey: dicomCacheKey(volumeKey),
           info: volumeInfo[volumeKey],
+          name: getDisplayName(volumeInfo[volumeKey]),
           // for UI selection
           selectionKey,
           layerable,
@@ -300,7 +301,7 @@ export default defineComponent({
                 class="text--primary text-caption text-center series-desc mt-n3"
               >
                 <div class="text-ellipsis">
-                  {{ volume.info.SeriesDescription || '(no description)' }}
+                  {{ volume.name }}
                 </div>
               </v-card-text>
             </v-card>

--- a/src/store/datasets-dicom.ts
+++ b/src/store/datasets-dicom.ts
@@ -101,6 +101,22 @@ const readDicomTags = (dicomIO: DICOMIO, file: File) =>
     { name: 'WindowWidth', tag: '0028|1051' },
   ]);
 
+/**
+ * Trims and collapses multiple spaces into one.
+ * @param name
+ * @returns string
+ */
+const cleanupName = (name: string) => {
+  return name.trim().replace(/\s+/g, ' ');
+};
+
+export const getDisplayName = (info: VolumeInfo) => {
+  return (
+    cleanupName(info.SeriesDescription || info.SeriesNumber) ||
+    info.SeriesInstanceUID
+  );
+};
+
 export const useDICOMStore = defineStore('dicom', {
   state: (): State => ({
     sliceData: {},

--- a/src/store/datasets.ts
+++ b/src/store/datasets.ts
@@ -34,8 +34,10 @@ export type DataSelection = DICOMSelection | ImageSelection;
 
 export const getImageID = (selection: DataSelection) => {
   if (selection.type === 'image') return selection.dataID;
-  if (selection.type === 'dicom')
-    return useDICOMStore().volumeToImageID[selection.volumeKey]; // volume selected, but image may not have been made yet
+  if (selection.type === 'dicom') {
+    // possibly undefined because image may not have been made yet
+    return useDICOMStore().volumeToImageID[selection.volumeKey];
+  }
 
   const _exhaustiveCheck: never = selection;
   throw new Error(`invalid selection type ${_exhaustiveCheck}`);


### PR DESCRIPTION
* Long layer names were squishing the opacity slider horizontally to nothing.
* For DICOM sourced layers, use datasets-image name for layer name.

![image](https://github.com/Kitware/VolView/assets/16823231/8eea6a19-2429-4fd8-b5db-fc0d4cd1d2b9)



Will address #462 when this change lands:
https://github.com/Kitware/VolView/pull/444/files#diff-2e48f469094ddae541596589e83ce73d782a438463fffc512e952d1aedd57b73L361-R372