### PR TITLE
feat(vtkPiecewiseWidget): Support vertical movement of points

### DIFF
--- a/src/components/VolumeRendering.vue
+++ b/src/components/VolumeRendering.vue
@@ -120,7 +120,7 @@ export default defineComponent({
           {
             mode,
             shift: pwfWidget.getOpacityPointShift(),
-            shiftAlpha: pwfWidget.getOpacityAlphaShift(),
+            shiftAlpha: pwfWidget.getOpacityValueShift(),
           }
         );
       }
@@ -282,8 +282,8 @@ export default defineComponent({
     const rangeShift = ref(0);
     const rangeWidth = ref(0);
 
-    onKeyDown('Control', () => pwfWidget.setCtrlKeyIsDown(true));
-    onKeyUp('Control', () => pwfWidget.setCtrlKeyIsDown(false));
+    onKeyDown('Control', () => pwfWidget.setShiftOpacityValues(true));
+    onKeyUp('Control', () => pwfWidget.setShiftOpacityValues(false));
 
     // reset case
     watch(

--- a/src/components/VolumeRendering.vue
+++ b/src/components/VolumeRendering.vue
@@ -7,6 +7,7 @@ import {
   watch,
   watchEffect,
 } from 'vue';
+import { onKeyDown, onKeyUp } from '@vueuse/core';
 import { PresetNameList } from '@/src/vtk/ColorMaps';
 import vtkPiecewiseWidget from '@/src/vtk/PiecewiseWidget';
 import type { vtkSubscription } from '@kitware/vtk.js/interfaces';
@@ -119,6 +120,7 @@ export default defineComponent({
           {
             mode,
             shift: pwfWidget.getOpacityPointShift(),
+            shiftAlpha: pwfWidget.getOpacityAlphaShift(),
           }
         );
       }
@@ -227,9 +229,10 @@ export default defineComponent({
           const points = getShiftedOpacityFromPreset(
             opFunc.preset,
             opFunc.mappingRange,
+            0,
             0
           );
-          pwfWidget.setOpacityPoints(points, opFunc.shift);
+          pwfWidget.setOpacityPoints(points, opFunc.shift, opFunc.shiftAlpha);
         }
       },
       { immediate: true }
@@ -278,6 +281,9 @@ export default defineComponent({
 
     const rangeShift = ref(0);
     const rangeWidth = ref(0);
+
+    onKeyDown('Control', () => pwfWidget.setCtrlKeyIsDown(true));
+    onKeyUp('Control', () => pwfWidget.setCtrlKeyIsDown(false));
 
     // reset case
     watch(

--- a/src/components/VtkThreeView.vue
+++ b/src/components/VtkThreeView.vue
@@ -361,7 +361,8 @@ function useColoringEffect(
           const opacityPoints = getShiftedOpacityFromPreset(
             opacityFunc.preset,
             opacityFunc.mappingRange,
-            opacityFunc.shift
+            opacityFunc.shift,
+            opacityFunc.shiftAlpha
           );
           if (opacityPoints) {
             pwf.setPoints(opacityPoints);

--- a/src/components/VtkTwoView.vue
+++ b/src/components/VtkTwoView.vue
@@ -824,7 +824,7 @@ export default defineComponent({
                     opFunc.preset,
                     opFunc.mappingRange,
                     opFunc.shift,
-                    opFunc.shiftAlpha,
+                    opFunc.shiftAlpha
                   );
                   if (opacityPoints) {
                     pwf.setPoints(opacityPoints);

--- a/src/components/VtkTwoView.vue
+++ b/src/components/VtkTwoView.vue
@@ -823,7 +823,8 @@ export default defineComponent({
                   const opacityPoints = getShiftedOpacityFromPreset(
                     opFunc.preset,
                     opFunc.mappingRange,
-                    opFunc.shift
+                    opFunc.shift,
+                    opFunc.shiftAlpha,
                   );
                   if (opacityPoints) {
                     pwf.setPoints(opacityPoints);

--- a/src/io/state-file/schema.ts
+++ b/src/io/state-file/schema.ts
@@ -153,6 +153,7 @@ const OpacityPoints = z.object({
   mode: z.literal(vtkPiecewiseFunctionProxy.Mode.Points),
   preset: z.string(),
   shift: z.number(),
+  shiftAlpha: z.number(),
   mappingRange: z.tuple([z.number(), z.number()]),
 }) satisfies z.ZodType<OpacityPoints>;
 

--- a/src/types/views.ts
+++ b/src/types/views.ts
@@ -27,6 +27,7 @@ export interface OpacityPoints {
   // base preset that has the opacity points
   preset: string;
   shift: number;
+  shiftAlpha: number;
   mappingRange: [number, number];
 }
 

--- a/src/utils/vtk-helpers.ts
+++ b/src/utils/vtk-helpers.ts
@@ -129,7 +129,7 @@ export function getShiftedOpacityFromPreset(
 
     const [xmin, xmax] = effectiveRange;
     const width = xmax - xmin;
-    return points.map(([x, y]) => [(x - xmin) / width + shift, y + shiftAlpha]);
+    return points.map(([x, y]) => [(x - xmin) / width + shift, y - shiftAlpha]);
   }
   return null;
 }

--- a/src/utils/vtk-helpers.ts
+++ b/src/utils/vtk-helpers.ts
@@ -129,7 +129,13 @@ export function getShiftedOpacityFromPreset(
 
     const [xmin, xmax] = effectiveRange;
     const width = xmax - xmin;
-    return points.map(([x, y]) => [(x - xmin) / width + shift, y - shiftAlpha]);
+    return points.map(([x, y]) => {
+      // Non-zero values should be affected by shift
+      // but preset values of zero should not
+      const shifted = y && y - shiftAlpha;
+      const yVal = Math.max(Math.min(shifted, 1), 0);
+      return [(x - xmin) / width + shift, yVal];
+    });
   }
   return null;
 }

--- a/src/utils/vtk-helpers.ts
+++ b/src/utils/vtk-helpers.ts
@@ -116,7 +116,8 @@ export function getCSSCoordinatesFromEvent(eventData: any) {
 export function getShiftedOpacityFromPreset(
   presetName: string,
   effectiveRange: [number, number],
-  shift: number
+  shift: number,
+  shiftAlpha: number
 ) {
   const preset = vtkColorMaps.getPresetByName(presetName);
   if (preset.OpacityPoints) {
@@ -128,7 +129,7 @@ export function getShiftedOpacityFromPreset(
 
     const [xmin, xmax] = effectiveRange;
     const width = xmax - xmin;
-    return points.map(([x, y]) => [(x - xmin) / width + shift, y]);
+    return points.map(([x, y]) => [(x - xmin) / width + shift, y + shiftAlpha]);
   }
   return null;
 }
@@ -146,6 +147,7 @@ export function getOpacityFunctionFromPreset(
       mode: vtkPiecewiseFunctionProxy.Mode.Points,
       preset: presetName,
       shift: 0,
+      shiftAlpha: 0,
     };
   }
   return {

--- a/src/vtk/PiecewiseWidget/index.js
+++ b/src/vtk/PiecewiseWidget/index.js
@@ -75,7 +75,7 @@ function vtkPiecewiseWidget(publicAPI, model) {
   model.pwMode = Mode.Gaussians;
   model.opacityPoints = [];
   model.opacityPointShift = 0;
-  model.opacityAlphaShift = 0;
+  model.opacityValueShift = 0;
 
   publicAPI.setGaussiansMode = () => {
     model.pwMode = Mode.Gaussians;
@@ -92,9 +92,9 @@ function vtkPiecewiseWidget(publicAPI, model) {
   publicAPI.getMode = () => model.pwMode;
 
   publicAPI.shiftPosition = (coords, meta) => {
-    if (model.ctrlKeyIsDown) {
-      model.opacityAlphaShift =
-        meta.originalOpacityAlphaShift + coords[1] - meta.originalXY[1];
+    if (model.shiftOpacityValues) {
+      model.opacityValueShift =
+        meta.originalOpacityValueShift + coords[1] - meta.originalXY[1];
     } else {
       model.opacityPointShift =
         meta.originalOpacityPointShift + coords[0] - meta.originalXY[0];
@@ -137,7 +137,7 @@ function vtkPiecewiseWidget(publicAPI, model) {
     model.dragAction = {
       originalXY: mouseCoords,
       originalOpacityPointShift: model.opacityPointShift,
-      originalOpacityAlphaShift: model.opacityAlphaShift,
+      originalOpacityValueShift: model.opacityValueShift,
     };
 
     return true;
@@ -157,7 +157,7 @@ function vtkPiecewiseWidget(publicAPI, model) {
       model.opacities = samplePiecewiseLinear(
         model.opacityPoints,
         model.opacityPointShift,
-        model.opacityAlphaShift
+        model.opacityValueShift
       );
       publicAPI.invokeOpacityChange(publicAPI, true);
     }
@@ -171,12 +171,12 @@ function vtkPiecewiseWidget(publicAPI, model) {
       // deep copy
       model.opacityPoints = points.map((p) => [p[0], p[1]]);
       model.opacityPointShift = shift;
-      model.opacityAlphaShift = shiftAlpha;
+      model.opacityValueShift = shiftAlpha;
 
       model.opacities = samplePiecewiseLinear(
         model.opacityPoints,
         model.opacityPointShift,
-        model.opacityAlphaShift
+        model.opacityValueShift
       );
       publicAPI.modified();
     }
@@ -185,7 +185,7 @@ function vtkPiecewiseWidget(publicAPI, model) {
   publicAPI.getEffectiveOpacityPoints = () =>
     model.opacityPoints.map((p) => [
       p[0] + model.opacityPointShift,
-      p[1] + model.opacityAlphaShift,
+      p[1] + model.opacityValueShift,
     ]);
 
   publicAPI.render = () => {
@@ -213,8 +213,8 @@ export function extend(publicAPI, model, initialValues = {}) {
   macro.setGet(publicAPI, model, [
     'opacityPoints',
     'opacityPointShift',
-    'opacityAlphaShift',
-    'ctrlKeyIsDown',
+    'opacityValueShift',
+    'shiftOpacityValues',
   ]);
 
   // Object specific methods

--- a/src/vtk/PiecewiseWidget/index.js
+++ b/src/vtk/PiecewiseWidget/index.js
@@ -52,7 +52,11 @@ export function samplePiecewiseLinear(
       } else if (slope === -Infinity) {
         sampledPoints.push(0);
       } else {
-        sampledPoints.push(slope * (sx - p1[0]) + (p1[1] - shiftAlpha));
+        // Non-zero values should be affected by shift
+        // but original values of zero should not
+        let value = slope * (sx - p1[0]) + p1[1];
+        value = value && value - shiftAlpha;
+        sampledPoints.push(value);
       }
     }
   }


### PR DESCRIPTION
Vertical shift is allowed when holding control and left-click+dragging up/down. Shifting the points changes opacity.

Initial pass at fixing #188