### PR TITLE
Offscreen views

### DIFF
--- a/src/components/VtkThreeView.vue
+++ b/src/components/VtkThreeView.vue
@@ -449,6 +449,7 @@ export default defineComponent({
       viewProxy.value.setOrientationAxesVisibility(true);
       viewProxy.value.setOrientationAxesType('cube');
       viewProxy.value.setBackground([0, 0, 0, 0]);
+      viewProxy.value.setInteractionContainer(canvasRef.value);
       // setViewProxyContainer(vtkContainerRef.value);
     });
 
@@ -458,6 +459,8 @@ export default defineComponent({
 
     useResizeObserver(vtkContainerRef, (entry) => {
       const bbox = entry.contentRect;
+      if (!bbox.width || !bbox.height) return;
+
       canvasRef.value?.setAttribute(
         'width',
         String(bbox.width * window.devicePixelRatio)

--- a/src/components/VtkThreeView.vue
+++ b/src/components/VtkThreeView.vue
@@ -443,7 +443,6 @@ export default defineComponent({
       const ctx = canvasRef.value.getContext('2d');
       const src = viewProxy.value.getOpenGLRenderWindow().getCanvas();
       if (ctx && src) ctx.drawImage(src, 0, 0);
-      if (src) console.log(src.width, src.height);
     });
 
     onMounted(() => {
@@ -455,7 +454,6 @@ export default defineComponent({
 
     onBeforeUnmount(() => {
       // setViewProxyContainer(null);
-      viewProxy.value.setContainer(null);
     });
 
     useResizeObserver(vtkContainerRef, (entry) => {

--- a/src/components/VtkThreeView.vue
+++ b/src/components/VtkThreeView.vue
@@ -442,7 +442,10 @@ export default defineComponent({
       if (!canvasRef.value) return;
       const ctx = canvasRef.value.getContext('2d');
       const src = viewProxy.value.getOpenGLRenderWindow().getCanvas();
-      if (ctx && src) ctx.drawImage(src, 0, 0);
+      if (ctx && src) {
+        ctx.clearRect(0, 0, canvasRef.value.width, canvasRef.value.height);
+        ctx.drawImage(src, 0, 0);
+      }
     });
 
     onMounted(() => {

--- a/src/components/VtkTwoView.vue
+++ b/src/components/VtkTwoView.vue
@@ -412,7 +412,10 @@ export default defineComponent({
       if (!canvasRef.value) return;
       const ctx = canvasRef.value.getContext('2d');
       const src = viewProxy.value.getOpenGLRenderWindow().getCanvas();
-      if (ctx && src) ctx.drawImage(src, 0, 0);
+      if (ctx && src) {
+        ctx.clearRect(0, 0, canvasRef.value.width, canvasRef.value.height);
+        ctx.drawImage(src, 0, 0);
+      }
     });
 
     onBeforeMount(() => {

--- a/src/components/VtkTwoView.vue
+++ b/src/components/VtkTwoView.vue
@@ -475,6 +475,8 @@ export default defineComponent({
 
     useResizeObserver(vtkContainerRef, (entry) => {
       const bbox = entry.contentRect;
+      if (!bbox.width || !bbox.height) return;
+
       canvasRef.value?.setAttribute(
         'width',
         String(bbox.width * window.devicePixelRatio)

--- a/src/components/VtkTwoView.vue
+++ b/src/components/VtkTwoView.vue
@@ -423,6 +423,7 @@ export default defineComponent({
 
     onMounted(() => {
       // setViewProxyContainer(vtkContainerRef.value);
+      viewProxy.value.setInteractionContainer(canvasRef.value);
       viewProxy.value.setOrientationAxesVisibility(false);
     });
 

--- a/src/composables/useViewProxy.ts
+++ b/src/composables/useViewProxy.ts
@@ -1,6 +1,6 @@
 import vtkViewProxy from '@kitware/vtk.js/Proxy/Core/ViewProxy';
-import { computed, onUnmounted, ref, unref, watch, watchEffect } from 'vue';
-import { MaybeRef, useElementSize } from '@vueuse/core';
+import { computed, onUnmounted, ref, unref, watch } from 'vue';
+import { MaybeRef } from '@vueuse/core';
 import { onVTKEvent } from '@/src/composables/onVTKEvent';
 import { Maybe } from '@/src/types';
 import { ViewProxyType } from '../core/proxies';
@@ -44,21 +44,14 @@ export function useViewProxy<T extends vtkViewProxy = vtkViewProxy>(
 function useMountedViewProxy<T extends vtkViewProxy = vtkViewProxy>(
   viewProxy: MaybeRef<Maybe<T>>
 ) {
-  const mounted = ref(false);
-
   const container = ref<Maybe<HTMLElement>>(unref(viewProxy)?.getContainer());
   onVTKEvent<vtkViewProxy, 'onModified'>(viewProxy, 'onModified', () => {
     container.value = unref(viewProxy)?.getContainer();
   });
 
-  const { width, height } = useElementSize(container);
-
-  const updateMounted = () => {
-    // view is considered mounted when the container has a non-zero size
-    mounted.value = !!(width.value && height.value);
-  };
-
-  watchEffect(() => updateMounted());
+  const mounted = computed(() => {
+    return !!container.value;
+  });
 
   return mounted;
 }

--- a/src/composables/useViewProxy.ts
+++ b/src/composables/useViewProxy.ts
@@ -23,7 +23,9 @@ export function useViewProxy<T extends vtkViewProxy = vtkViewProxy>(
   );
 
   watch(viewProxy, (curViewProxy, oldViewProxy) => {
-    oldViewProxy.setContainer(null);
+    if (oldViewProxy !== curViewProxy) {
+      oldViewProxy.setContainer(null);
+    }
     curViewProxy.setContainer(container.value);
   });
 

--- a/src/vtk/LPSView2DProxy/index.d.ts
+++ b/src/vtk/LPSView2DProxy/index.d.ts
@@ -1,8 +1,12 @@
 import { vec3 } from 'gl-matrix';
 import { vtkView2DProxy } from '@kitware/vtk.js/Proxy/Core/View2DProxy';
-import { ViewProxyCustomizations } from '@/src/vtk/LPSView3DProxy';
+import vtkLPSView3DProxy, {
+  ViewProxyCustomizations,
+} from '@/src/vtk/LPSView3DProxy';
 
-export interface vtkLPSView2DProxy extends vtkView2DProxy {
+export interface vtkLPSView2DProxy
+  extends vtkView2DProxy,
+    ViewProxyCustomizations {
   resizeToFit(lookAxis: Vector3, viewUpAxis: Vector3, worldDims: Vector3);
   resetCamera(boundsToUse?: number[]);
   /**

--- a/src/vtk/LPSView3DProxy/index.d.ts
+++ b/src/vtk/LPSView3DProxy/index.d.ts
@@ -1,13 +1,20 @@
 import { vec3 } from 'gl-matrix';
 import vtkViewProxy from '@kitware/vtk.js/Proxy/Core/ViewProxy';
 import vtkInteractorStyleManipulator from '@kitware/vtk.js/Interaction/Style/InteractorStyleManipulator';
+import { Maybe } from '@/src/types';
 
-export interface vtkLPSView3DProxy extends vtkViewProxy {
+export interface ViewProxyCustomizations {
   removeAllRepresentations(): void;
   updateCamera(directionOfProjection: vec3, viewUp: vec3, focalPoint: vec3);
   getInteractorStyle2D(): vtkInteractorStyleManipulator;
   getInteractorStyle3D(): vtkInteractorStyleManipulator;
+  setInteractionContainer(el: Maybe<HTMLElement>): boolean;
+  getInteractionContainer(): Maybe<HTMLElement>;
 }
+
+export interface vtkLPSView3DProxy
+  extends vtkViewProxy,
+    ViewProxyCustomizations {}
 
 export function commonViewCustomizations(publicAPI: any, model: any): void;
 

--- a/src/vtk/LPSView3DProxy/index.js
+++ b/src/vtk/LPSView3DProxy/index.js
@@ -4,11 +4,12 @@ import vtkViewProxy from '@kitware/vtk.js/Proxy/Core/ViewProxy';
 
 export function commonViewCustomizations(publicAPI, model) {
   const delayedRender = macro.debounce(model.renderWindow.render, 5);
+  model.size = { width: 0, height: 0 };
 
   // override resize to avoid flickering from rendering later
   publicAPI.resize = () => {
     if (model.container) {
-      const dims = model.container.getBoundingClientRect();
+      const dims = model.size;
       if (dims.width === dims.height && dims.width === 0) {
         return;
       }
@@ -68,6 +69,15 @@ export function commonViewCustomizations(publicAPI, model) {
     resetCamera(args);
     model.renderer.updateLightsGeometryToFollowCamera();
   };
+
+  publicAPI.setSize = (width, height) => {
+    model.size = { width, height };
+    publicAPI.resize();
+  };
+
+  // initialize
+
+  publicAPI.setContainer(document.createElement('div'));
 }
 
 function vtkLPSView3DProxy(publicAPI, model) {

--- a/src/vtk/LPSView3DProxy/index.js
+++ b/src/vtk/LPSView3DProxy/index.js
@@ -91,9 +91,11 @@ export function commonViewCustomizations(publicAPI, model) {
   publicAPI.setSize = (width, height) => {
     const container = publicAPI.getContainer();
     if (!container) throw new Error('No container');
-    container.style.width = `${width}px`;
-    container.style.height = `${height}px`;
-    publicAPI.resize();
+    setTimeout(() => {
+      container.style.width = `${width}px`;
+      container.style.height = `${height}px`;
+      publicAPI.resize();
+    }, 0);
   };
 
   publicAPI.setInteractionContainer = (el) => {

--- a/src/vtk/vtkOffscreenRenderWindowInteractor/index.ts
+++ b/src/vtk/vtkOffscreenRenderWindowInteractor/index.ts
@@ -51,6 +51,8 @@ function vtkOffscreenRenderWindowInteractor(
   publicAPI: vtkOffscreenRenderWindowInteractor,
   model: Model
 ) {
+  model.classHierarchy.push('vtkOffscreenRenderWindowInteractor');
+
   const { setInteractionContainer } = publicAPI;
 
   publicAPI.setInteractionContainer = (el: Maybe<HTMLElement>) => {

--- a/src/vtk/vtkOffscreenRenderWindowInteractor/index.ts
+++ b/src/vtk/vtkOffscreenRenderWindowInteractor/index.ts
@@ -1,0 +1,95 @@
+import { Maybe } from '@/src/types';
+import * as macros from '@kitware/vtk.js/macros';
+import vtkRenderWindowInteractor from '@kitware/vtk.js/Rendering/Core/RenderWindowInteractor';
+
+export interface vtkOffscreenRenderWindowInteractor
+  extends vtkRenderWindowInteractor {
+  bindInteractionContainer(): void;
+  unbindInteractionContainer(): void;
+  setInteractionContainer(el: Maybe<HTMLElement>): boolean;
+  getInteractionContainer(): Maybe<HTMLElement>;
+}
+
+interface Model {
+  interactor: vtkRenderWindowInteractor;
+  interactionContainer: Maybe<HTMLElement>;
+  [prop: string]: any;
+}
+
+function replaceGetScreenEventPositionFor(
+  publicAPI: vtkOffscreenRenderWindowInteractor,
+  model: Model
+) {
+  function updateCurrentRenderer(x: number, y: number) {
+    if (!model._forcedRenderer) {
+      model.currentRenderer = publicAPI.findPokedRenderer(x, y);
+    }
+  }
+
+  function getScreenEventPositionFor(source: PointerEvent) {
+    if (!model.interactionContainer)
+      throw new Error('Interaction container is not set!');
+
+    const canvas = model._view.getCanvas();
+    const bounds = model.interactionContainer.getBoundingClientRect();
+    const scaleX = canvas.width / bounds.width;
+    const scaleY = canvas.height / bounds.height;
+    const position = {
+      x: scaleX * (source.clientX - bounds.left),
+      y: scaleY * (bounds.height - source.clientY + bounds.top),
+      z: 0,
+    };
+
+    updateCurrentRenderer(position.x, position.y);
+    return position;
+  }
+
+  model._getScreenEventPositionFor = getScreenEventPositionFor;
+}
+
+function vtkOffscreenRenderWindowInteractor(
+  publicAPI: vtkOffscreenRenderWindowInteractor,
+  model: Model
+) {
+  const { setInteractionContainer } = publicAPI;
+
+  publicAPI.setInteractionContainer = (el: Maybe<HTMLElement>) => {
+    if (model.container) {
+      publicAPI.unbindEvents();
+    }
+
+    const changed = setInteractionContainer(el);
+
+    if (el) {
+      publicAPI.bindEvents(el);
+    }
+
+    return changed;
+  };
+}
+
+export function extend(
+  publicAPI: vtkOffscreenRenderWindowInteractor,
+  model: Model,
+  initialValues = {}
+) {
+  // should happen before extending the RenderWindowInteractor
+  replaceGetScreenEventPositionFor(publicAPI, model);
+
+  vtkRenderWindowInteractor.extend(publicAPI, model, initialValues);
+
+  macros.setGet(publicAPI, model, ['interactionContainer']);
+
+  vtkOffscreenRenderWindowInteractor(
+    publicAPI as vtkOffscreenRenderWindowInteractor,
+    model as Model
+  );
+}
+
+export const newInstance = macros.newInstance(
+  // @ts-ignore TODO fix this typing issue
+  extend,
+  'vtkOffscreenRenderWindowInteractor'
+);
+
+export default { newInstance, extend };


### PR DESCRIPTION
Views are rendered offscreen and kept persistent across layout changes. This should speed up layout changes and hopefully reduce potential webgl context losses from (theoretical) rapid unmount/mount of the rendering container.

Instead of having interaction and rendering occur on a single canvas, rendering is now performed on a dedicated offscreen canvas. Pixels are copied over from the rendering canvas to the interaction canvas, and interaction events are handled appropriately.

@aylward please test this out to see if it helps with context loss issues.