### PR TITLE
fix(mimeTypes): handle windows zip mime type

### DIFF
--- a/src/io/mimeTypes.ts
+++ b/src/io/mimeTypes.ts
@@ -67,4 +67,8 @@ export const MIME_TYPES = new Set(Object.values(FILE_EXT_TO_MIME));
 /**
  * Supported archives
  */
-export const ARCHIVE_FILE_TYPES = new Set(['application/zip']);
+export const ARCHIVE_FILE_TYPES = new Set([
+  FILE_EXT_TO_MIME.zip,
+  // Windows uploads files with this non-standard mime type
+  'application/x-zip-compressed',
+]);


### PR DESCRIPTION
Fixes #500

Windows uses the non-standard `application/x-zip-compressed` mime type when opening zip files via the file picker. Other platforms (and even drag-and-drop on Windows) uses `application/zip`.

This change adds `application/x-zip-compressed` as a supported mime type.