### PR TITLE
Report global errors

### DIFF
--- a/src/components/DataSecurityBox.vue
+++ b/src/components/DataSecurityBox.vue
@@ -3,12 +3,14 @@ import {
   errorReportingConfigured,
   useErrorReporting,
 } from '@/src/utils/errorReporting';
-import { watch, ref } from 'vue';
+import { computed } from 'vue';
 
 const errorStore = useErrorReporting();
-const reportingEnabled = ref(!errorStore.disableReporting);
-watch(reportingEnabled, (enabled) => {
-  errorStore.disableReporting = !enabled;
+const reportingEnabled = computed({
+  get: () => !errorStore.disableReporting,
+  set: (enabled) => {
+    errorStore.disableReporting = !enabled;
+  },
 });
 </script>
 

--- a/src/composables/useGlobalErrorHook.ts
+++ b/src/composables/useGlobalErrorHook.ts
@@ -1,4 +1,5 @@
 import { onBeforeUnmount, onMounted } from 'vue';
+import { captureException } from '@sentry/vue';
 import { useMessageStore } from '../store/messages';
 
 export function useGlobalErrorHook() {
@@ -6,9 +7,11 @@ export function useGlobalErrorHook() {
 
   const onError = (event: ErrorEvent) => {
     console.error(event);
-    const details = event.error
-      ? event.error
-      : { details: event.message ?? 'Unknown error' };
+    const errorMessage = event.message ?? 'Unknown global error';
+
+    captureException(event.error ?? errorMessage);
+
+    const details = event.error ? event.error : { details: errorMessage };
     messageStore.addError('Application error (click for details)', details);
   };
 


### PR DESCRIPTION
- Adds a call to captureException on global errors
- Fixes reportingEnabled not being reactive