### PR TITLE
Paint tool on startup fixes

### DIFF
--- a/src/components/tools/paint/PaintWidget2D.vue
+++ b/src/components/tools/paint/PaintWidget2D.vue
@@ -155,7 +155,8 @@ export default defineComponent({
 
     const viewInteractor = computed(() => viewProxy.value!.getInteractor());
 
-    // Turn on widget visibility if mouse starts within view
+    // Turn on widget visibility and update stencil
+    // if mouse starts within view
     onVTKEvent(viewInteractor, 'onMouseMove', () => {
       if (!checkIfPointerInView) {
         return;
@@ -163,6 +164,7 @@ export default defineComponent({
       checkIfPointerInView = false;
 
       widgetRef.value!.setVisibility(true);
+      paintStore.setSliceAxis(viewAxisIndex.value);
     });
 
     onVTKEvent(viewInteractor, 'onMouseEnter', () => {

--- a/src/store/tools/index.ts
+++ b/src/store/tools/index.ts
@@ -95,7 +95,11 @@ export const useToolStore = defineStore('tool', {
     ) {
       const { tools } = manifest;
 
+      usePaintToolStore().deserialize(manifest, segmentGroupIDMap);
+
       Object.values(ToolStoreMap)
+        // paint store uses segmentGroupIDMap
+        .filter((useStore) => useStore !== usePaintToolStore)
         .map((useStore) => useStore?.())
         .filter((store): store is IToolStore => !!store)
         .forEach((store) => {

--- a/src/store/tools/paint.ts
+++ b/src/store/tools/paint.ts
@@ -191,13 +191,14 @@ export const usePaintToolStore = defineStore('paint', () => {
   ) {
     const { paint } = manifest.tools;
     setBrushSize.call(this, paint.brushSize);
-    setActiveSegment.call(this, paint.activeSegment);
     setLabelmapOpacity.call(this, paint.labelmapOpacity);
     isActive.value = manifest.tools.current === Tools.Paint;
 
     if (paint.activeSegmentGroupID !== null) {
       activeSegmentGroupID.value =
         segmentGroupIDMap[paint.activeSegmentGroupID];
+      setActiveLabelmap(activeSegmentGroupID.value);
+      setActiveSegment.call(this, paint.activeSegment);
     }
   }
 


### PR DESCRIPTION
Small paint tool fixes:
- If session.volview.zip is loaded with the paint tool initially selected, clicking on the image did not paint.
- If paint tool is activated when mouse is within a view, the stencil shape would not be correct.