### PR TITLE
fix(sidebar): show toggle sidebar button by default

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -3,11 +3,7 @@
     <template v-slot="{ dragHover }">
       <v-app>
         <v-app-bar app clipped-left :height="48">
-          <v-btn
-            v-if="mobile"
-            icon="mdi-menu"
-            @click="leftSideBar = !leftSideBar"
-          />
+          <v-btn icon="mdi-menu" @click="leftSideBar = !leftSideBar" />
           <v-toolbar-title class="d-flex flex-row align-center mt-3">
             <vol-view-logo v-if="mobile" />
             <vol-view-full-logo v-else />


### PR DESCRIPTION
Addresses: https://github.com/Kitware/VolView/issues/519

Show the "toggle sidebar" button by default on all platforms. Earlier it was only enabled for mobile devices. Showing the button on all platforms will enable the user to explicitly show/hide the sidebar as desired.