### PR TITLE
Support overriding the current image

### DIFF
--- a/src/components/CurrentImageProvider.vue
+++ b/src/components/CurrentImageProvider.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+import { Maybe } from '@/src/types';
+import { provide, toRefs } from 'vue';
+import { CurrentImageInjectionKey } from '@/src/composables/useCurrentImage';
+
+const props = defineProps<{
+  imageId: Maybe<string>;
+}>();
+
+const { imageId: imageID } = toRefs(props);
+
+provide(CurrentImageInjectionKey, {
+  imageID,
+});
+</script>
+
+<template>
+  <slot />
+</template>

--- a/src/components/VtkObliqueView.vue
+++ b/src/components/VtkObliqueView.vue
@@ -219,7 +219,7 @@ export default defineComponent({
       get: () => windowingStore.getConfig(viewID.value, curImageID.value),
       set: (newValue) => {
         const imageID = curImageID.value;
-        if (imageID !== null && newValue != null) {
+        if (imageID != null && newValue != null) {
           windowingStore.updateConfig(viewID.value, imageID, newValue);
         }
       },
@@ -229,7 +229,7 @@ export default defineComponent({
     const windowLevel = computed(() => wlConfig.value?.level);
     const dicomInfo = computed(() => {
       if (
-        curImageID.value !== null &&
+        curImageID.value != null &&
         curImageID.value in dicomStore.imageIDToVolumeKey
       ) {
         const volumeKey = dicomStore.imageIDToVolumeKey[curImageID.value];

--- a/src/components/VtkTwoView.vue
+++ b/src/components/VtkTwoView.vue
@@ -333,7 +333,7 @@ export default defineComponent({
       get: () => windowingStore.getConfig(viewID.value, curImageID.value),
       set: (newValue) => {
         const imageID = curImageID.value;
-        if (imageID !== null && newValue != null) {
+        if (imageID != null && newValue != null) {
           windowingStore.updateConfig(viewID.value, imageID, newValue);
         }
       },
@@ -346,7 +346,7 @@ export default defineComponent({
     );
     const dicomInfo = computed(() => {
       if (
-        curImageID.value !== null &&
+        curImageID.value != null &&
         curImageID.value in dicomStore.imageIDToVolumeKey
       ) {
         const volumeKey = dicomStore.imageIDToVolumeKey[curImageID.value];
@@ -388,7 +388,7 @@ export default defineComponent({
     // --- setters --- //
 
     const setSlice = (slice: number) => {
-      if (curImageID.value !== null) {
+      if (curImageID.value != null) {
         viewSliceStore.updateConfig(viewID.value, curImageID.value, {
           slice,
         });

--- a/src/components/VtkTwoView.vue
+++ b/src/components/VtkTwoView.vue
@@ -863,7 +863,7 @@ export default defineComponent({
         .filter(
           ({ tool }) =>
             tool.slice === currentSlice.value &&
-            doesToolFrameMatchViewAxis(viewAxis, tool)
+            doesToolFrameMatchViewAxis(viewAxis, tool, curImageMetadata)
         )
         .flatMap(({ store, tool }) => store.getPoints(tool.id));
     });

--- a/src/components/tools/SliceScrollTool.vue
+++ b/src/components/tools/SliceScrollTool.vue
@@ -96,7 +96,7 @@ export default defineComponent({
         range.step,
         () => scrollVal.value,
         (slice) => {
-          if (currentImageID.value !== null) {
+          if (currentImageID.value != null) {
             viewSliceStore.updateConfig(viewID.value, currentImageID.value, {
               slice,
             });

--- a/src/composables/useCurrentImage.ts
+++ b/src/composables/useCurrentImage.ts
@@ -1,12 +1,32 @@
-import { computed } from 'vue';
-import { useDatasetStore } from '../store/datasets';
-import { useDICOMStore } from '../store/datasets-dicom';
-import { defaultImageMetadata, useImageStore } from '../store/datasets-images';
-import { useLayersStore } from '../store/datasets-layers';
-import { createLPSBounds, getAxisBounds } from '../utils/lps';
+import {
+  InjectionKey,
+  MaybeRef,
+  Ref,
+  computed,
+  hasInjectionContext,
+  inject,
+  unref,
+} from 'vue';
+import { Maybe } from '@/src/types';
+import {
+  defaultImageMetadata,
+  useImageStore,
+} from '@/src/store/datasets-images';
+import { useLayersStore } from '@/src/store/datasets-layers';
+import { createLPSBounds, getAxisBounds } from '@/src/utils/lps';
+import { getImageID, useDatasetStore } from '@/src/store/datasets';
+import { storeToRefs } from 'pinia';
+
+export interface CurrentImageContext {
+  imageID: Ref<Maybe<string>>;
+}
+
+export const CurrentImageInjectionKey = Symbol(
+  'CurrentImage'
+) as InjectionKey<CurrentImageContext>;
 
 // Returns a spatially inflated image extent
-export function getImageSpatialExtent(imageID: string | null) {
+export function getImageSpatialExtent(imageID: Maybe<string>) {
   const imageStore = useImageStore();
 
   if (imageID && imageID in imageStore.metadata) {
@@ -24,62 +44,59 @@ export function getImageSpatialExtent(imageID: string | null) {
   return createLPSBounds();
 }
 
-export function useCurrentImage() {
+export function getImageMetadata(imageID: Maybe<string>) {
+  const { metadata } = useImageStore();
+  return imageID ? metadata[imageID] : defaultImageMetadata();
+}
+
+export function getImageData(imageID: Maybe<string>) {
+  const { dataIndex } = useImageStore();
+  return imageID ? dataIndex[imageID] : null;
+}
+
+export function getIsImageLoading(imageID: Maybe<string>) {
   const dataStore = useDatasetStore();
-  const dicomStore = useDICOMStore();
-  const imageStore = useImageStore();
+  if (!dataStore.primarySelection) return false;
+
+  const selectedImageID = getImageID(dataStore.primarySelection);
+  if (selectedImageID !== unref(imageID)) return false;
+
+  return !!dataStore.primarySelection && !dataStore.primaryDataset;
+}
+
+export function getImageLayers(imageID: Maybe<string>) {
   const layersStore = useLayersStore();
+  return layersStore
+    .getLayers(imageID ? { type: 'image', dataID: imageID } : null)
+    .filter(({ id }) => id in layersStore.layerImages);
+}
 
-  const currentImageID = computed(() => {
-    const { primarySelection } = dataStore;
-    const { volumeToImageID } = dicomStore;
-
-    if (primarySelection?.type === 'image') {
-      return primarySelection.dataID;
-    }
-    if (primarySelection?.type === 'dicom') {
-      return volumeToImageID[primarySelection.volumeKey] || null;
-    }
-    return null;
-  });
-
-  const currentImageMetadata = computed(() => {
-    const { metadata } = imageStore;
-    const imageID = currentImageID.value;
-
-    if (imageID) {
-      return metadata[imageID];
-    }
-    return defaultImageMetadata();
-  });
-
-  const currentImageData = computed(() => {
-    if (currentImageID.value)
-      // assumed to be only images for now
-      return imageStore.dataIndex[currentImageID.value];
-    return undefined;
-  });
-
-  const currentImageExtent = computed(() =>
-    getImageSpatialExtent(currentImageID.value)
-  );
-
-  const isImageLoading = computed(() => {
-    return !!dataStore.primarySelection && !dataStore.primaryDataset;
-  });
-
-  const currentLayers = computed(() =>
-    layersStore
-      .getLayers(dataStore.primarySelection)
-      .filter(({ id }) => id in layersStore.layerImages)
-  );
-
+export function useImage(imageID: MaybeRef<Maybe<string>>) {
   return {
-    currentImageData,
-    currentImageID,
-    currentImageMetadata,
-    currentImageExtent,
-    isImageLoading,
-    currentLayers,
+    id: computed(() => unref(imageID)),
+    imageData: computed(() => getImageData(unref(imageID))),
+    metadata: computed(() => getImageMetadata(unref(imageID))),
+    extent: computed(() => getImageSpatialExtent(unref(imageID))),
+    isLoading: computed(() => getIsImageLoading(unref(imageID))),
+    layers: computed(() => getImageLayers(unref(imageID))),
+  };
+}
+
+export function useCurrentImage() {
+  const { primaryImageID } = storeToRefs(useDatasetStore());
+  const defaultContext = { imageID: primaryImageID };
+  const { imageID } = hasInjectionContext()
+    ? inject(CurrentImageInjectionKey, defaultContext)
+    : defaultContext;
+
+  const { id, imageData, metadata, extent, isLoading, layers } =
+    useImage(imageID);
+  return {
+    currentImageID: id,
+    currentImageMetadata: metadata,
+    currentImageData: imageData,
+    currentImageExtent: extent,
+    isImageLoading: isLoading,
+    currentLayers: layers,
   };
 }

--- a/src/composables/usePersistCameraConfig.ts
+++ b/src/composables/usePersistCameraConfig.ts
@@ -1,12 +1,13 @@
 import { manageVTKSubscription } from '@/src/composables/manageVTKSubscription';
 import { Ref } from 'vue';
+import { Maybe } from '@/src/types';
 import { CameraConfig } from '../store/view-configs/types';
 import { vtkLPSViewProxy } from '../types/vtk-types';
 import useViewCameraStore from '../store/view-configs/camera';
 
 export function usePersistCameraConfig(
   viewID: Ref<string>,
-  dataID: Ref<string | null>,
+  dataID: Ref<Maybe<string>>,
   viewProxy: Ref<vtkLPSViewProxy>,
   ...toPersist: (keyof CameraConfig)[]
 ) {
@@ -19,7 +20,7 @@ export function usePersistCameraConfig(
 
   if (toPersist.indexOf('position') > -1) {
     persist.push(() => {
-      if (dataID.value !== null && persistCameraConfig) {
+      if (dataID.value != null && persistCameraConfig) {
         viewCameraStore.updateConfig(viewID.value, dataID.value, {
           position: viewProxy.value.getCamera().getPosition(),
         });
@@ -28,7 +29,7 @@ export function usePersistCameraConfig(
   }
   if (toPersist.indexOf('viewUp') > -1) {
     persist.push(() => {
-      if (dataID.value !== null && persistCameraConfig) {
+      if (dataID.value != null && persistCameraConfig) {
         viewCameraStore.updateConfig(viewID.value, dataID.value, {
           viewUp: viewProxy.value.getCamera().getViewUp(),
         });
@@ -37,7 +38,7 @@ export function usePersistCameraConfig(
   }
   if (toPersist.indexOf('focalPoint') > -1) {
     persist.push(() => {
-      if (dataID.value !== null && persistCameraConfig) {
+      if (dataID.value != null && persistCameraConfig) {
         viewCameraStore.updateConfig(viewID.value, dataID.value, {
           focalPoint: viewProxy.value.getCamera().getFocalPoint(),
         });
@@ -46,7 +47,7 @@ export function usePersistCameraConfig(
   }
   if (toPersist.indexOf('directionOfProjection') > -1) {
     persist.push(() => {
-      if (dataID.value !== null && persistCameraConfig) {
+      if (dataID.value != null && persistCameraConfig) {
         viewCameraStore.updateConfig(viewID.value, dataID.value, {
           directionOfProjection: viewProxy.value
             .getCamera()
@@ -57,7 +58,7 @@ export function usePersistCameraConfig(
   }
   if (toPersist.indexOf('parallelScale') > -1) {
     persist.push(() => {
-      if (dataID.value !== null && persistCameraConfig) {
+      if (dataID.value != null && persistCameraConfig) {
         viewCameraStore.updateConfig(viewID.value, dataID.value, {
           parallelScale: viewProxy.value.getCamera().getParallelScale(),
         });

--- a/src/composables/useSceneBuilder.ts
+++ b/src/composables/useSceneBuilder.ts
@@ -1,11 +1,12 @@
 import vtkAbstractRepresentationProxy from '@kitware/vtk.js/Proxy/Core/AbstractRepresentationProxy';
 import { computed, Ref, watch } from 'vue';
+import { Maybe } from '@/src/types';
 import { useViewStore } from '../store/views';
 import { vtkLPSViewProxy } from '../types/vtk-types';
 import { arrayEquals } from '../utils';
 
 interface Scene {
-  baseImage?: Ref<string | null>;
+  baseImage?: Ref<Maybe<string>>;
   labelmaps?: Ref<string[]>;
   layers?: Ref<string[]>;
   models?: Ref<string[]>;

--- a/src/store/datasets.ts
+++ b/src/store/datasets.ts
@@ -179,6 +179,7 @@ export const useDatasetStore = defineStore('dataset', () => {
   });
 
   return {
+    primaryImageID,
     primarySelection,
     primaryDataset,
     allDataIDs,

--- a/src/store/tools/crop.ts
+++ b/src/store/tools/crop.ts
@@ -9,6 +9,7 @@ import { MaybeRef } from '@vueuse/core';
 import { vec3 } from 'gl-matrix';
 import { defineStore } from 'pinia';
 import { arrayEqualsWithComparator } from '@/src/utils';
+import { Maybe } from '@/src/types';
 import { useImageStore } from '../datasets-images';
 import { LPSCroppingPlanes } from '../../types/crop';
 import { ImageMetadata } from '../../types/image';
@@ -89,7 +90,7 @@ export const useCropStore = defineStore('crop', () => {
     croppingByImageID: {} as Record<string, LPSCroppingPlanes>,
   });
 
-  const getComputedVTKPlanes = (imageID: MaybeRef<string | null>) =>
+  const getComputedVTKPlanes = (imageID: MaybeRef<Maybe<string>>) =>
     computed(() => {
       const id = unref(imageID);
       if (id && id in state.croppingByImageID && id in imageStore.metadata) {

--- a/src/store/tools/paint.ts
+++ b/src/store/tools/paint.ts
@@ -15,7 +15,7 @@ export const usePaintToolStore = defineStore('paint', () => {
   type _This = ReturnType<typeof usePaintToolStore>;
 
   const activeMode = ref(PaintMode.CirclePaint);
-  const activeSegmentGroupID = ref<string | null>(null);
+  const activeSegmentGroupID = ref<Maybe<string>>(null);
   const activeSegment = ref<Maybe<number>>(null);
   const brushSize = ref(DEFAULT_BRUSH_SIZE);
   const strokePoints = ref<vec3[]>([]);
@@ -48,7 +48,7 @@ export const usePaintToolStore = defineStore('paint', () => {
   /**
    * Sets the active labelmap.
    */
-  function setActiveLabelmap(segmentGroupID: string | null) {
+  function setActiveLabelmap(segmentGroupID: Maybe<string>) {
     activeSegmentGroupID.value = segmentGroupID;
   }
 
@@ -57,7 +57,7 @@ export const usePaintToolStore = defineStore('paint', () => {
    *
    * If a labelmap exists, pick the first one. If no labelmap exists, create one.
    */
-  function setActiveLabelmapFromImage(imageID: string | null) {
+  function setActiveLabelmapFromImage(imageID: Maybe<string>) {
     if (!imageID) {
       setActiveLabelmap(null);
       return;
@@ -178,7 +178,7 @@ export const usePaintToolStore = defineStore('paint', () => {
   function serialize(state: StateFile) {
     const { paint } = state.manifest.tools;
 
-    paint.activeSegmentGroupID = activeSegmentGroupID.value;
+    paint.activeSegmentGroupID = activeSegmentGroupID.value ?? null;
     paint.brushSize = brushSize.value;
     paint.activeSegment = activeSegment.value;
     paint.labelmapOpacity = labelmapOpacity.value;

--- a/src/store/tools/useAnnotationTool.ts
+++ b/src/store/tools/useAnnotationTool.ts
@@ -136,9 +136,10 @@ export const useAnnotationTool = <
     });
   });
 
+  const { currentImageID, currentImageMetadata } = useCurrentImage();
+
   function jumpToTool(toolID: ToolID) {
     const tool = toolByID.value[toolID];
-    const { currentImageID, currentImageMetadata } = useCurrentImage();
 
     const imageID = currentImageID.value;
     if (!imageID || tool.imageID !== imageID) return;


### PR DESCRIPTION
The `CurrentImageProvider` component can now override the image returned from `useCurrentImage()` for a given subtree. The fallback behavior is to use the current global selected image.

This revives #410 with the fallback behavior.