### PR TITLE
fix(urlParams): empty save param issue

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -202,7 +202,7 @@ export default defineComponent({
     // --- save state --- //
 
     const remoteSaveStateStore = useRemoteSaveStateStore();
-    if (import.meta.env.VITE_ENABLE_REMOTE_SAVE) {
+    if (import.meta.env.VITE_ENABLE_REMOTE_SAVE && urlParams.save) {
       remoteSaveStateStore.setSaveUrl(urlParams.save.toString());
     }
 


### PR DESCRIPTION
Fix the following error when urlParams are empty.
```js
App.vue:206 Uncaught TypeError: Cannot read properties of undefined (reading 'toString')
    at setup (App.vue:206:54)
    at callWithErrorHandling (chunk-G4DFXOZZ.js?v=fae193fd:1565:18)
    at setupStatefulComponent (chunk-G4DFXOZZ.js?v=fae193fd:8631:25)
    at setupComponent (chunk-G4DFXOZZ.js?v=fae193fd:8592:36)
    at mountComponent (chunk-G4DFXOZZ.js?v=fae193fd:6997:7)
    at processComponent (chunk-G4DFXOZZ.js?v=fae193fd:6963:9)
    at patch (chunk-G4DFXOZZ.js?v=fae193fd:6436:11)
    at render2 (chunk-G4DFXOZZ.js?v=fae193fd:7730:7)
    at mount (chunk-G4DFXOZZ.js?v=fae193fd:5215:13)
    at app.mount (chunk-G4DFXOZZ.js?v=fae193fd:10537:19)
```