### PR TITLE
fix(App): keep query params on save url query param

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -201,9 +201,14 @@ export default defineComponent({
 
     // --- save state --- //
 
-    const remoteSaveStateStore = useRemoteSaveStateStore();
     if (import.meta.env.VITE_ENABLE_REMOTE_SAVE && urlParams.save) {
-      remoteSaveStateStore.setSaveUrl(urlParams.save.toString());
+      // Avoid dropping JSON or array query param arguments on the "save" query parameter
+      // by parsing query params without casting to native types in vtkURLExtract.
+      const queryParams = new URLSearchParams(window.location.search);
+      const saveUrl = queryParams.get('save');
+      if (saveUrl) {
+        useRemoteSaveStateStore().setSaveUrl(saveUrl);
+      }
     }
 
     // --- layout --- //


### PR DESCRIPTION
Avoid dropping JSON or array query param arguments on the "save" query parameter by parsing query params without casting to native types in vtkURLExtract.

Now save parameter could be
`/api/v1/folder/65e1f44870447d7525ac0c49/volview?metadata={"linkedResources":{"items":["65e1f4ec70447d7525ac0c54"]}}`