### PR TITLE
Prefer some DICOMs modalities as primary selection and layer a PET on a CT if it exists

### DIFF
--- a/src/io/import/importDataSources.ts
+++ b/src/io/import/importDataSources.ts
@@ -172,20 +172,21 @@ export type ImportDataSourcesResult = Awaited<
   ReturnType<typeof importDataSources>
 >[number];
 
+export function toDataSelection(loadable: LoadableResult) {
+  const { dataID, dataType } = loadable;
+  if (dataType === 'dicom') {
+    return makeDICOMSelection(dataID);
+  }
+  if (dataType === 'image') {
+    return makeImageSelection(dataID);
+  }
+  return null;
+}
+
 export function convertSuccessResultToDataSelection(
   result: ImportDataSourcesResult
 ) {
   if (!isSelectable(result)) return null;
 
-  const { dataID, dataType } = result.data[0];
-
-  if (dataType === 'dicom') {
-    return makeDICOMSelection(dataID);
-  }
-
-  if (dataType === 'image') {
-    return makeImageSelection(dataID);
-  }
-
-  return null;
+  return toDataSelection(result.data[0]);
 }

--- a/src/store/load-data.ts
+++ b/src/store/load-data.ts
@@ -20,6 +20,7 @@ import { computed, ref, watch } from 'vue';
 import { useToast } from '@/src/composables/useToast';
 import { TYPE } from 'vue-toastification';
 import { ToastID, ToastOptions } from 'vue-toastification/dist/types/types';
+import { useLayersStore } from './datasets-layers';
 
 const BASE_MODALITY_TYPES = ['CT', 'MR', 'DX', 'US'];
 
@@ -125,14 +126,55 @@ function pickBaseDicom(loadableDataSources: Array<LoadableResult>) {
   });
 }
 
-function pickBaseDataset(
+function pickLoadableDataSources(
   succeeded: Array<PipelineResultSuccess<ImportResult>>
 ) {
-  const loadableDataSources = succeeded.flatMap((result) => {
+  return succeeded.flatMap((result) => {
     return result.data.filter(isLoadableResult);
   });
+}
+
+function pickBaseDataSource(
+  succeeded: Array<PipelineResultSuccess<ImportResult>>
+) {
+  const loadableDataSources = pickLoadableDataSources(succeeded);
   const baseDicom = pickBaseDicom(loadableDataSources);
   return baseDicom ?? loadableDataSources[0];
+}
+
+function getStudyUID(volumeID: string) {
+  const dicomStore = useDICOMStore();
+  const studyKey = dicomStore.volumeStudy[volumeID];
+  return dicomStore.studyInfo[studyKey].StudyInstanceUID;
+}
+
+function loadLayers(
+  primaryDataSource: LoadableResult,
+  succeeded: Array<PipelineResultSuccess<ImportResult>>
+) {
+  if (primaryDataSource.dataType !== 'dicom') return;
+  const dicomDataSources = pickLoadableDataSources(succeeded).filter(
+    ({ dataType }) => dataType === 'dicom'
+  );
+  const studyID = getStudyUID(primaryDataSource.dataID);
+  const otherVolumesInStudy = dicomDataSources.filter((ds) => {
+    const studyUID = getStudyUID(ds.dataID);
+    return studyUID === studyID && ds.dataID !== primaryDataSource.dataID;
+  });
+  const dicomStore = useDICOMStore();
+  const primaryModality =
+    dicomStore.volumeInfo[primaryDataSource.dataID].Modality;
+  // Look for one PET volume to layer with CT.  Only one as there are often multiple "White Balance" corrected PET volumes.
+  const toLayer = otherVolumesInStudy.find((ds) => {
+    const otherModality = dicomStore.volumeInfo[ds.dataID].Modality;
+    return primaryModality === 'CT' && otherModality === 'PT';
+  });
+  if (!toLayer) return;
+
+  const primarySelection = toDataSelection(primaryDataSource)!;
+  const layersStore = useLayersStore();
+  const layerSelection = toDataSelection(toLayer)!;
+  layersStore.addLayer(primarySelection, layerSelection);
 }
 
 const useLoadDataStore = defineStore('loadData', () => {
@@ -164,10 +206,11 @@ const useLoadDataStore = defineStore('loadData', () => {
     const [succeeded, errored] = partitionResults(results);
 
     if (!dataStore.primarySelection && succeeded.length) {
-      const primaryDataset = pickBaseDataset(succeeded);
-      const selection = toDataSelection(primaryDataset);
+      const primaryDataSource = pickBaseDataSource(succeeded);
+      const selection = toDataSelection(primaryDataSource);
       if (selection) {
         dataStore.setPrimarySelection(selection);
+        loadLayers(primaryDataSource, succeeded);
       }
     }
 


### PR DESCRIPTION
The "base" DICOM modalties: 'CT', 'MR', 'DX', 'US'

Side effect: When an image and DICOM are loaded at same time, DICOM is always Primary Selection.

PR does not change Sample Data and DICOMWeb behavior (which only load single volumes at a time at the moment.)

Related issue: #566 