### PR TITLE
feat: unify data IDs

### DIFF
--- a/src/components/DataBrowser.vue
+++ b/src/components/DataBrowser.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { computed, defineComponent, ref, watch } from 'vue';
+import { isRegularImage } from '@/src/utils/dataSelection';
 import SampleDataBrowser from './SampleDataBrowser.vue';
 import { useDicomWebStore } from '../store/dicom-web/dicom-web-store';
 import ImageDataBrowser from './ImageDataBrowser.vue';
@@ -42,9 +43,7 @@ export default defineComponent({
     );
 
     const hasAnonymousImages = computed(
-      () =>
-        imageStore.idList.filter((id) => !(id in dicomStore.imageIDToVolumeKey))
-          .length > 0
+      () => imageStore.idList.filter((id) => isRegularImage(id)).length > 0
     );
 
     const panels = ref<string[]>([SAMPLE_DATA_KEY, DICOM_WEB_KEY]);

--- a/src/components/DicomQuickInfoButton.vue
+++ b/src/components/DicomQuickInfoButton.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { useDICOMStore } from '@/src/store/datasets-dicom';
 import { Maybe } from '@/src/types';
+import { isDicomImage } from '@/src/utils/dataSelection';
 import { computed, toRef } from 'vue';
 
 interface Props {
@@ -12,8 +13,8 @@ const imageId = toRef(props, 'imageId');
 
 const dicomStore = useDICOMStore();
 const dicomInfo = computed(() => {
-  if (imageId.value != null && imageId.value in dicomStore.imageIDToVolumeKey) {
-    const volumeKey = dicomStore.imageIDToVolumeKey[imageId.value];
+  const volumeKey = imageId.value;
+  if (volumeKey && isDicomImage(volumeKey)) {
     const volumeInfo = dicomStore.volumeInfo[volumeKey];
     const studyKey = dicomStore.volumeStudy[volumeKey];
     const studyInfo = dicomStore.studyInfo[studyKey];

--- a/src/components/LayerProperties.vue
+++ b/src/components/LayerProperties.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 import { computed, defineComponent, PropType, toRefs } from 'vue';
-import { getImageID } from '@/src/utils/dataSelection';
 import { InitViewSpecs } from '../config';
 import { useImageStore } from '../store/datasets-images';
 import { BlendConfig } from '../types/views';
@@ -25,9 +24,7 @@ export default defineComponent({
 
     const imageName = computed(() => {
       const { selection } = props.layer;
-      const imageID = getImageID(selection);
-      if (imageID === undefined) throw new Error('imageID is undefined');
-      return imageStore.metadata[imageID].name;
+      return imageStore.metadata[selection].name;
     });
 
     const layerColoringStore = useLayerColoringStore();

--- a/src/components/PatientBrowser.vue
+++ b/src/components/PatientBrowser.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { computed, defineComponent, ref, toRefs, watch } from 'vue';
 import ItemGroup from '@/src/components/ItemGroup.vue';
-import { DataSelection, selectionEquals } from '@/src/utils/dataSelection';
+import { type DataSelection, selectionEquals } from '@/src/utils/dataSelection';
 import { useDICOMStore } from '../store/datasets-dicom';
 import { useDatasetStore } from '../store/datasets';
 import { useMultiSelection } from '../composables/useMultiSelection';

--- a/src/components/PatientStudyVolumeBrowser.vue
+++ b/src/components/PatientStudyVolumeBrowser.vue
@@ -3,7 +3,7 @@ import { computed, defineComponent, reactive, toRefs, watch } from 'vue';
 import { Image } from 'itk-wasm';
 import type { PropType } from 'vue';
 import GroupableItem from '@/src/components/GroupableItem.vue';
-import { DataSelection, DICOMSelection } from '@/src/utils/dataSelection';
+import { DataSelection, isDicomImage } from '@/src/utils/dataSelection';
 import { getDisplayName, useDICOMStore } from '../store/datasets-dicom';
 import { useDatasetStore } from '../store/datasets';
 import { useMultiSelection } from '../composables/useMultiSelection';
@@ -78,21 +78,16 @@ export default defineComponent({
       const primarySelection = primarySelectionRef.value;
       const layerVolumes = layersStore
         .getLayers(primarySelection)
-        .filter(({ selection }) => selection.type === 'dicom');
-      const layerVolumeKeys = layerVolumes.map(
-        ({ selection }) => (selection as DICOMSelection).volumeKey
-      );
+        .filter(({ selection }) => isDicomImage(selection));
+      const layerVolumeKeys = layerVolumes.map(({ selection }) => selection);
       const loadedLayerVolumeKeys = layerVolumes
         .filter(({ id }) => id in layersStore.layerImages)
-        .map(({ selection }) => (selection as DICOMSelection).volumeKey);
+        .map(({ selection }) => selection);
       const selectedVolumeKey =
-        primarySelection?.type === 'dicom' && primarySelection.volumeKey;
+        isDicomImage(primarySelection) && primarySelection;
 
       return volumeKeys.value.map((volumeKey) => {
-        const selectionKey = {
-          type: 'dicom',
-          volumeKey,
-        } as DataSelection;
+        const selectionKey = volumeKey as DataSelection;
         const isLayer = layerVolumeKeys.includes(volumeKey);
         const layerLoaded = loadedLayerVolumeKeys.includes(volumeKey);
         const layerLoading = isLayer && !layerLoaded;

--- a/src/components/SampleDataBrowser.vue
+++ b/src/components/SampleDataBrowser.vue
@@ -102,12 +102,10 @@ export default defineComponent({
 
         const selection = convertSuccessResultToDataSelection(loadResult);
         if (selection) {
-          const id =
-            selection.type === 'image' ? selection.dataID : selection.volumeKey;
-          loaded.idToURL[id] = sample.url;
-          loaded.urlToID[sample.url] = id;
+          loaded.idToURL[selection] = sample.url;
+          loaded.urlToID[sample.url] = selection;
 
-          useVolumeColoringStore().setDefaults(id, {
+          useVolumeColoringStore().setDefaults(selection, {
             transferFunction: {
               preset: sample.defaults?.colorPreset,
             },

--- a/src/components/SliceViewer.vue
+++ b/src/components/SliceViewer.vue
@@ -177,6 +177,7 @@ import VtkMouseInteractionManipulator from '@/src/components/vtk/VtkMouseInterac
 import vtkMouseCameraTrackballPanManipulator from '@kitware/vtk.js/Interaction/Manipulators/MouseCameraTrackballPanManipulator';
 import vtkMouseCameraTrackballZoomToMouseManipulator from '@kitware/vtk.js/Interaction/Manipulators/MouseCameraTrackballZoomToMouseManipulator';
 import { useResetViewsEvents } from '@/src/components/tools/ResetViews.vue';
+import { whenever } from '@vueuse/core';
 
 interface Props extends LayoutViewProps {
   viewDirection: LPSAxisDir;
@@ -214,6 +215,13 @@ const { currentImageID, currentLayers, currentImageMetadata, isImageLoading } =
 const { slice: currentSlice, range: sliceRange } = useSliceConfig(
   viewId,
   currentImageID
+);
+
+whenever(
+  computed(() => !isImageLoading.value),
+  () => {
+    resetCamera();
+  }
 );
 
 // segmentations

--- a/src/components/VolumeViewer.vue
+++ b/src/components/VolumeViewer.vue
@@ -74,6 +74,7 @@ import VtkOrientationMarker from '@/src/components/vtk/VtkOrientationMarker.vue'
 import ViewOverlayGrid from '@/src/components/ViewOverlayGrid.vue';
 import useVolumeColoringStore from '@/src/store/view-configs/volume-coloring';
 import { useResetViewsEvents } from '@/src/components/tools/ResetViews.vue';
+import { whenever } from '@vueuse/core';
 
 interface Props extends LayoutViewProps {
   viewDirection: LPSAxisDir;
@@ -99,6 +100,13 @@ useViewAnimationListener(vtkView, viewId, viewType);
 
 // base image
 const { currentImageID, isImageLoading } = useCurrentImage();
+
+whenever(
+  computed(() => !isImageLoading.value),
+  () => {
+    resetCamera();
+  }
+);
 
 // color preset
 const coloringStore = useVolumeColoringStore();

--- a/src/components/tools/windowing/WindowLevelControls.vue
+++ b/src/components/tools/windowing/WindowLevelControls.vue
@@ -7,6 +7,7 @@ import useWindowingStore, {
 import { useViewStore } from '@/src/store/views';
 import { WLAutoRanges, WLPresetsCT, WL_AUTO_DEFAULT } from '@/src/constants';
 import { getWindowLevels, useDICOMStore } from '@/src/store/datasets-dicom';
+import { isDicomImage } from '@/src/utils/dataSelection';
 
 export default defineComponent({
   setup() {
@@ -31,11 +32,8 @@ export default defineComponent({
     // --- CT Preset Options --- //
 
     const modality = computed(() => {
-      if (
-        currentImageID.value &&
-        currentImageID.value in dicomStore.imageIDToVolumeKey
-      ) {
-        const volKey = dicomStore.imageIDToVolumeKey[currentImageID.value];
+      if (currentImageID.value && isDicomImage(currentImageID.value)) {
+        const volKey = currentImageID.value;
         const { Modality } = dicomStore.volumeInfo[volKey];
         return Modality;
       }
@@ -98,11 +96,8 @@ export default defineComponent({
 
     // --- Tag WL Options --- //
     const tags = computed(() => {
-      if (
-        currentImageID.value &&
-        currentImageID.value in dicomStore.imageIDToVolumeKey
-      ) {
-        const volKey = dicomStore.imageIDToVolumeKey[currentImageID.value];
+      if (currentImageID.value && isDicomImage(currentImageID.value)) {
+        const volKey = currentImageID.value;
         return getWindowLevels(dicomStore.volumeInfo[volKey]);
       }
       return [];

--- a/src/composables/useCurrentImage.ts
+++ b/src/composables/useCurrentImage.ts
@@ -15,7 +15,6 @@ import {
 import { useLayersStore } from '@/src/store/datasets-layers';
 import { createLPSBounds, getAxisBounds } from '@/src/utils/lps';
 import { useDatasetStore } from '@/src/store/datasets';
-import { getDataSelection, getImageID } from '@/src/utils/dataSelection';
 import { storeToRefs } from 'pinia';
 
 export interface CurrentImageContext {
@@ -57,21 +56,16 @@ export function getImageData(imageID: Maybe<string>) {
 }
 
 export function getIsImageLoading(imageID: Maybe<string>) {
-  const dataStore = useDatasetStore();
-  if (!dataStore.primarySelection) return false;
-
-  const selectedImageID = getImageID(dataStore.primarySelection);
-  if (selectedImageID !== unref(imageID)) return false;
-
-  return !!dataStore.primarySelection && !dataStore.primaryDataset;
+  if (!imageID) return false;
+  const imageStore = useImageStore();
+  return !imageStore.dataIndex[imageID];
 }
 
 export function getImageLayers(imageID: Maybe<string>) {
   if (!imageID) return [];
-  const selection = getDataSelection(imageID);
   const layersStore = useLayersStore();
   return layersStore
-    .getLayers(selection)
+    .getLayers(imageID)
     .filter(({ id }) => id in layersStore.layerImages);
 }
 

--- a/src/composables/useSliceConfigInitializer.ts
+++ b/src/composables/useSliceConfigInitializer.ts
@@ -16,7 +16,7 @@ export function useSliceConfigInitializer(
 ) {
   const store = useViewSliceStore();
   const { config: sliceConfig } = useSliceConfig(viewID, imageID);
-  const { metadata } = useImage(imageID);
+  const { metadata, isLoading } = useImage(imageID);
 
   const viewAxis = computed(() => getLPSAxisFromDir(unref(viewDirection)));
   const sliceDomain = computed(() => {
@@ -33,17 +33,22 @@ export function useSliceConfigInitializer(
   });
 
   watchImmediate(
-    [toRef(sliceDomain), toRef(viewDirection)] as const,
-    ([domain, axisDirection]) => {
+    [
+      toRef(sliceDomain),
+      toRef(viewDirection),
+      toRef(imageID),
+      isLoading,
+    ] as const,
+    ([domain, axisDirection, id, loading]) => {
+      if (loading || !id) return;
+
       const configExisted = !!sliceConfig.value;
-      const imageIdVal = unref(imageID);
-      if (!imageIdVal) return;
-      store.updateConfig(unref(viewID), imageIdVal, {
+      store.updateConfig(unref(viewID), id, {
         ...domain,
         axisDirection,
       });
       if (!configExisted) {
-        store.resetSlice(unref(viewID), imageIdVal);
+        store.resetSlice(unref(viewID), id);
       }
     }
   );

--- a/src/composables/useVolumeColoringInitializer.ts
+++ b/src/composables/useVolumeColoringInitializer.ts
@@ -13,10 +13,10 @@ export function useVolumeColoringInitializer(
     store.getConfig(unref(viewId), unref(imageId))
   );
 
-  const { imageData } = useImage(imageId);
+  const { imageData, isLoading } = useImage(imageId);
 
-  watchImmediate(coloringConfig, (config) => {
-    if (config) return;
+  watchImmediate([coloringConfig, viewId, imageId, isLoading], () => {
+    if (coloringConfig.value || isLoading.value) return;
 
     const viewIdVal = unref(viewId);
     const imageIdVal = unref(imageId);

--- a/src/composables/useWindowingConfigInitializer.ts
+++ b/src/composables/useWindowingConfigInitializer.ts
@@ -9,6 +9,7 @@ import { getWindowLevels, useDICOMStore } from '@/src/store/datasets-dicom';
 import useWindowingStore from '@/src/store/view-configs/windowing';
 import { Maybe } from '@/src/types';
 import { useResetViewsEvents } from '@/src/components/tools/ResetViews.vue';
+import { isDicomImage } from '@/src/utils/dataSelection';
 
 function useAutoRangeValues(imageID: MaybeRef<Maybe<string>>) {
   const { imageData } = useImage(imageID);
@@ -80,8 +81,8 @@ export function useWindowingConfigInitializer(
 
   const firstTag = computed(() => {
     const id = unref(imageID);
-    if (id && id in dicomStore.imageIDToVolumeKey) {
-      const volKey = dicomStore.imageIDToVolumeKey[id];
+    if (id && isDicomImage(id)) {
+      const volKey = id;
       const windowLevels = getWindowLevels(dicomStore.volumeInfo[volKey]);
       if (windowLevels.length) {
         return windowLevels[0];

--- a/src/io/import/importDataSources.ts
+++ b/src/io/import/importDataSources.ts
@@ -22,10 +22,6 @@ import restoreStateFile from '@/src/io/import/processors/restoreStateFile';
 import updateFileMimeType from '@/src/io/import/processors/updateFileMimeType';
 import handleConfig from '@/src/io/import/processors/handleConfig';
 import { useDICOMStore } from '@/src/store/datasets-dicom';
-import {
-  makeDICOMSelection,
-  makeImageSelection,
-} from '@/src/utils/dataSelection';
 import { applyConfig } from '@/src/io/import/configJson';
 
 /**
@@ -177,16 +173,8 @@ export type ImportDataSourcesResult = Awaited<
 >[number];
 
 export function toDataSelection(loadable: VolumeResult) {
-  const { dataID, dataType } = loadable;
-  if (dataType === 'dicom') {
-    return makeDICOMSelection(dataID);
-  }
-  if (dataType === 'image') {
-    return makeImageSelection(dataID);
-  }
-
-  const _exhaustiveCheck: never = dataType;
-  throw new Error(`invalid loadable type ${_exhaustiveCheck}`);
+  const { dataID } = loadable;
+  return dataID;
 }
 
 export function convertSuccessResultToDataSelection(

--- a/src/io/state-file/index.ts
+++ b/src/io/state-file/index.ts
@@ -12,7 +12,7 @@ import { retypeFile } from '../io';
 import { ARCHIVE_FILE_TYPES } from '../mimeTypes';
 
 export const MANIFEST = 'manifest.json';
-export const MANIFEST_VERSION = '3.0.0';
+export const MANIFEST_VERSION = '4.0.0';
 
 export async function serialize() {
   const datasetStore = useDatasetStore();

--- a/src/io/state-file/schema.ts
+++ b/src/io/state-file/schema.ts
@@ -1,30 +1,31 @@
 import JSZip from 'jszip';
 import { z } from 'zod';
 import type { Vector3 } from '@kitware/vtk.js/types';
-import vtkPiecewiseFunctionProxy, {
+import vtkPiecewiseFunctionProxy from '@kitware/vtk.js/Proxy/Core/PiecewiseFunctionProxy';
+import type {
   PiecewiseGaussian,
   PiecewiseNode,
 } from '@kitware/vtk.js/Proxy/Core/PiecewiseFunctionProxy';
 
 import type { AnnotationTool, ToolID } from '@/src/types/annotation-tool';
 import { Tools as ToolsEnum } from '@/src/store/tools/types';
-import { Ruler } from '@/src/types/ruler';
-import { Rectangle } from '@/src/types/rectangle';
-import { Polygon } from '@/src/types/polygon';
-import { LPSCroppingPlanes } from '@/src/types/crop';
-import { FrameOfReference } from '@/src/utils/frameOfReference';
-import { Optional } from '@/src/types';
+import type { Ruler } from '@/src/types/ruler';
+import type { Rectangle } from '@/src/types/rectangle';
+import type { Polygon } from '@/src/types/polygon';
+import type { LPSCroppingPlanes } from '@/src/types/crop';
+import type { FrameOfReference } from '@/src/utils/frameOfReference';
+import type { Optional } from '@/src/types';
 
-import {
+import type {
   CameraConfig,
   SliceConfig,
   WindowLevelConfig,
   LayersConfig,
   VolumeColorConfig,
 } from '../../store/view-configs/types';
-import { LPSAxisDir, LPSAxis } from '../../types/lps';
+import type { LPSAxisDir, LPSAxis } from '../../types/lps';
 import { LayoutDirection } from '../../types/layout';
-import {
+import type {
   ColorBy,
   ColorTransferFunction,
   OpacityFunction,

--- a/src/store/datasets-images.ts
+++ b/src/store/datasets-images.ts
@@ -36,8 +36,12 @@ export const useImageStore = defineStore('images', {
     metadata: Object.create(null),
   }),
   actions: {
-    addVTKImageData(name: string, imageData: vtkImageData) {
-      const id = useIdStore().nextId();
+    addVTKImageData(name: string, imageData: vtkImageData, useId?: string) {
+      if (useId && useId in this.dataIndex) {
+        throw new Error('ID already exists');
+      }
+
+      const id = useId || useIdStore().nextId();
 
       this.idList.push(id);
       this.dataIndex[id] = imageData;

--- a/src/store/tools/useAnnotationTool.ts
+++ b/src/store/tools/useAnnotationTool.ts
@@ -13,7 +13,6 @@ import { useViewStore } from '@/src/store/views';
 import { getLPSAxisFromDir } from '@/src/utils/lps';
 import { LPSAxisDir } from '@/src/types/lps';
 import { AnnotationTool, ToolID } from '@/src/types/annotation-tool';
-import { findImageID, getDataID } from '@/src/utils/dataSelection';
 import { useIdStore } from '@/src/store/id';
 import { useToolSelectionStore } from '@/src/store/tools/toolSelection';
 import type { IToolStore } from '@/src/store/tools/types';
@@ -171,8 +170,7 @@ export const useAnnotationTool = <
       .map((toolID) => toolByID.value[toolID])
       .filter((tool) => !tool.placing)
       .map(({ imageID, ...rest }) => ({
-        // If parent image is DICOM, save VolumeKey
-        imageID: getDataID(imageID),
+        imageID,
         ...rest,
       }));
 
@@ -205,7 +203,7 @@ export const useAnnotationTool = <
         ({ imageID, label, ...rest }) =>
           ({
             ...rest,
-            imageID: findImageID(dataIDMap[imageID]),
+            imageID: dataIDMap[imageID],
             label: (label && labelIDMap[label]) || '',
           } as ToolPatch)
       )

--- a/src/store/view-configs/layers.ts
+++ b/src/store/view-configs/layers.ts
@@ -15,6 +15,7 @@ import {
 import { Maybe } from '@/src/types';
 import { identity } from '@/src/utils';
 import { LAYER_PRESET_BY_MODALITY, LAYER_PRESET_DEFAULT } from '@/src/config';
+import { isDicomImage } from '@/src/utils/dataSelection';
 import { createViewConfigSerializer } from './common';
 import { ViewConfig } from '../../io/state-file/schema';
 import { LayersConfig } from './types';
@@ -28,10 +29,9 @@ function getPreset(id: LayerID) {
     throw new Error(`Layer ${id} not found`);
   }
 
-  if (layer.selection.type === 'dicom') {
+  if (isDicomImage(layer.selection)) {
     const dicomStore = useDICOMStore();
-    const { Modality = undefined } =
-      dicomStore.volumeInfo[layer.selection.volumeKey];
+    const { Modality = undefined } = dicomStore.volumeInfo[layer.selection];
     return (
       (Modality && LAYER_PRESET_BY_MODALITY[Modality]) || LAYER_PRESET_DEFAULT
     );

--- a/src/store/view-configs/volume-coloring.ts
+++ b/src/store/view-configs/volume-coloring.ts
@@ -16,6 +16,7 @@ import {
 } from '@/src/utils/doubleKeyRecord';
 import { DeepPartial, Maybe } from '@/src/types';
 import { identity } from '@/src/utils';
+import { isDicomImage } from '@/src/utils/dataSelection';
 import { createViewConfigSerializer } from './common';
 import { ViewConfig } from '../../io/state-file/schema';
 import { VolumeColorConfig } from './types';
@@ -30,8 +31,8 @@ export const DEFAULT_SAMPLING_DISTANCE = 0.2;
 
 function getPresetFromImageModality(imageID: string) {
   const dicomStore = useDICOMStore();
-  if (imageID in dicomStore.imageIDToVolumeKey) {
-    const volKey = dicomStore.imageIDToVolumeKey[imageID];
+  if (isDicomImage(imageID)) {
+    const volKey = imageID;
     const { Modality } = dicomStore.volumeInfo[volKey];
     if (Modality in DEFAULT_PRESET_BY_MODALITY) {
       return DEFAULT_PRESET_BY_MODALITY[Modality];

--- a/src/utils/dataSelection.ts
+++ b/src/utils/dataSelection.ts
@@ -1,95 +1,42 @@
 import { getDisplayName, useDICOMStore } from '@/src/store/datasets-dicom';
 import { useImageStore } from '@/src/store/datasets-images';
 import { useErrorMessage } from '@/src/composables/useErrorMessage';
+import { Maybe } from '@/src/types';
 
-export const makeDICOMSelection = (volumeKey: string) =>
-  ({
-    type: 'dicom',
-    volumeKey,
-  } as const);
+export type DataSelection = string;
 
-export type DICOMSelection = ReturnType<typeof makeDICOMSelection>;
+export const selectionEquals = (a: DataSelection, b: DataSelection) => a === b;
 
-export const makeImageSelection = (imageID: string) =>
-  ({
-    type: 'image',
-    dataID: imageID,
-  } as const);
-
-export type ImageSelection = ReturnType<typeof makeImageSelection>;
-
-export type DataSelection = DICOMSelection | ImageSelection;
-
-export const getImageID = (selection: DataSelection) => {
-  if (selection.type === 'image') return selection.dataID;
-  if (selection.type === 'dicom') {
-    // possibly undefined because image may not have been made yet
-    return useDICOMStore().volumeToImageID[selection.volumeKey];
-  }
-
-  const _exhaustiveCheck: never = selection;
-  throw new Error(`invalid selection type ${_exhaustiveCheck}`);
+export const isDicomImage = (imageID: Maybe<string>) => {
+  if (!imageID) return false;
+  const store = useDICOMStore();
+  return imageID in store.volumeInfo;
 };
 
-export const getImage = async (selection: DataSelection) => {
+export const isRegularImage = (imageID: Maybe<string>) => {
+  if (!imageID) return false;
+  return !isDicomImage(imageID);
+};
+
+export const getImage = async (imageID: string) => {
   const images = useImageStore();
   const dicoms = useDICOMStore();
-  if (selection.type === 'dicom') {
+  if (isDicomImage(imageID)) {
     // ensure image data exists
     await useErrorMessage('Failed to build volume', () =>
-      dicoms.buildVolume(selection.volumeKey)
+      dicoms.buildVolume(imageID)
     );
-    return images.dataIndex[getImageID(selection)!];
   }
-  // just an image that should be in dataIndex
-  return images.dataIndex[selection.dataID];
+  return images.dataIndex[imageID];
 };
-
-// Converts imageID to VolumeKey if exists, else return input imageID
-export const getDataID = (imageID: string) => {
-  const dicomStore = useDICOMStore();
-  return dicomStore.imageIDToVolumeKey[imageID] ?? imageID;
-};
-
-// @param id - VolumeKey or ImageID
-export const getDataSelection = (id: string) => {
-  const dicomStore = useDICOMStore();
-  const volumeKey =
-    dicomStore.imageIDToVolumeKey[id] ??
-    (id in dicomStore.volumeInfo ? id : undefined);
-  if (volumeKey) {
-    return makeDICOMSelection(volumeKey);
-  }
-  return makeImageSelection(id);
-};
-
-// Pass VolumeKey or ImageID and get ImageID
-export const findImageID = (dataID: string) => {
-  const dicomStore = useDICOMStore();
-  return dicomStore.volumeToImageID[dataID] ?? dataID;
-};
-
-export function selectionEquals(s1: DataSelection, s2: DataSelection) {
-  if (s1.type === 'dicom' && s2.type === 'dicom') {
-    return s1.volumeKey === s2.volumeKey;
-  }
-  if (s1.type === 'image' && s2.type === 'image') {
-    return s1.dataID === s2.dataID;
-  }
-  return false;
-}
 
 const getImageName = (imageID: string) => {
   return useImageStore().metadata[imageID].name;
 };
 
-export const getSelectionName = (selection: DataSelection) => {
-  if (selection.type === 'image') return getImageName(selection.dataID);
-  if (selection.type === 'dicom') {
-    const imageID = getImageID(selection);
-    if (imageID) return getImageName(imageID);
-    return getDisplayName(useDICOMStore().volumeInfo[selection.volumeKey]);
+export const getSelectionName = (selection: string) => {
+  if (isDicomImage(selection)) {
+    return getDisplayName(useDICOMStore().volumeInfo[selection]);
   }
-  const _exhaustiveCheck: never = selection;
-  throw new Error(`invalid selection type ${_exhaustiveCheck}`);
+  return getImageName(selection);
 };


### PR DESCRIPTION
Volume keys are now used as image data IDs. This simplifies going back and forth between the image and dicom store, and simplifies the structure of the selection object to be just an ID string.

This doesn't address migration of older session files. That is a nice-to-have, but we don't have a good way of handling migrations at the moment. @PaulHax if this breaks stored session files, then I'll add a migration path.