### PR TITLE
fix(vuetify): add patch for expandable panels with v-model

### DIFF
--- a/src/components/DataBrowser.vue
+++ b/src/components/DataBrowser.vue
@@ -46,7 +46,36 @@ export default defineComponent({
       () => imageStore.idList.filter((id) => isRegularImage(id)).length > 0
     );
 
-    const panels = ref<string[]>([SAMPLE_DATA_KEY, DICOM_WEB_KEY]);
+    const panels = ref<string[]>([SAMPLE_DATA_KEY]);
+
+    watch(patients, (newPatients, oldPatients) => {
+      // Remove from panels to avoid error in vuetify group.ts
+      oldPatients.forEach((oldPatient) => {
+        if (!newPatients.find((p) => p.key === oldPatient.key)) {
+          removeFromArray(panels.value, oldPatient.key);
+        }
+      });
+    });
+
+    const hideSampleData = computed(() => dataBrowserStore.hideSampleData);
+    watch(hideSampleData, (hide) => {
+      if (hide) {
+        // Remove from panels to avoid error in vuetify group.ts
+        removeFromArray(panels.value, SAMPLE_DATA_KEY);
+      }
+    });
+
+    watch(
+      computed(() => dicomWeb.isConfigured),
+      (configured) => {
+        if (configured) {
+          panels.value.push(DICOM_WEB_KEY);
+        } else {
+          // Remove from panels to avoid error in vuetify group.ts
+          removeFromArray(panels.value, DICOM_WEB_KEY);
+        }
+      }
+    );
 
     watch(
       [hasAnonymousImages, patients] as const,
@@ -63,8 +92,6 @@ export default defineComponent({
         }
       }
     );
-
-    const hideSampleData = computed(() => dataBrowserStore.hideSampleData);
 
     const deletePatient = (key: string) => {
       dicomStore.patientStudies[key]


### PR DESCRIPTION
Dynamic number of panels with v-model='panels' has an error when removing a panel.

Steps: When I load the prostate, click checkbox to "select all studies," then "delete selected" -> seeing errors [Vue warn]: Unhandled error during execution of beforeUnmount hook and Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'value') at group.ts:338:59

I did not reproduce the error in the Vuetify playground, so not sure how to complain:
[playground](https://play.vuetifyjs.com/#eNqVVk1v2zgQ/SuEdgHJqCXF6e7Fm6RJt5feFthgL3GBKiIds6EogqTUBIb/+z5StCXZauP60Ebz8WbmzQzJh21kdJnfKZW1DYuW0ZUpNVeWGGYbdbOShPBK1dqSLdFsTXZkreuKxDCOV9Kpy1oai38bacm1s0kuZiONZoVlny2roE4st4LNyaYw/xWiYRBZ3bAZub4hydY5IR5ddnBZ60zevZt38s61+xvQlkm7JHEcJN522QN/IP9azeVTMoCakSVpJGVrLhn1frtRqhxJmlDEQ593Et/Fs/mgkCT+eCz4O559GWHV8o7SfdW+vn15LkiXT6Yas0mGMJ/iGVCQ1xjqExPMOrIS1qLsuQe5rz+yTkGH+HlOvFFmbK3+0bUqngrLa5l44EOpoOEFgMNsQAv97OSJkzpI93/GKbm+7iwHISEOgEMIowQvWeLR52RxWosqJBMHjuNFPCfxZbynDkN3zytWNzYZcbZnIJGNEF31IeLDwvkiyJxcXly4ybvKuwnG7OIDlkqAXj/JV21aqG6o/YebogKzoIPIC9kLcjQgLA25tmlVUyauV1EnWEWkaoTlSjBSisIYaIqyrDWF0yo6YE2h9TpMbLquNXw92Vx2Va2iocnymb0GC/B9pPP177X+Y2gwSGMqkdRv08gIZnu2yG9F6WbGlbYl3pUyik4Oqws+BsoDDzDYbsnXsIy/b/vcdl/JbofewPoUo005enEsRo1ODNhDBh9IXFGelhvWapTSqBgrPRLR+ruMx0x1v75VrrJTi/z8tMZQBMOB2ZyKGdJ3+f3Y6LbEzjy7Kt3auqk/jPtg22dvZ3yVj6Z9sq84/AoM7xl9bVNdfyeyTp8aa5k2JxZhhcSBDpquBQ6Vb42xfP2aGltoi2WBidMuFhNRAoplLzZdcybolIFblf0K+oHysztFpfuh0JJtakGZW677n5m2heaFdGSYWtRIQAh2tGX9b8MpQxdxYOAImLA4nR/XEc/QKbmQg93z+ueM397eqRUHq8ch3uzqr/X0crKnoaMFLrbj1oWLGxAT+zbJ1hRXk5SMq50w6U/5U11PBJJ/tP2JVlCauszTRxDmzo1+Xw9X/PGh79b+xi29Eo1xwbygN4Gb3+lhPoi5v5g8DcObyUm6i2s0Ivg09jXMQXaU6P7qrAr9xGWKt8CSXP6pXv4KVzKO4uAbzaPuiZdWhcq+mVriGei90TOvwK203OOtIjz93Pcq2lirzDLPSyrhhibzVmeS2VyqKr+FWa7x9MJ9jkO5un2f/ZG9X+SUGzuUZ8wgZTTYMA2UVRTecz6Om7kzYgVLH+KiixBEqSgejQtxAp0jXst0qhmOQM30uSUduY3KOtL9uDTFJS/GERupnp+wHlUelKFPu2g396+eyFcXffkfq7KIFQ==)
