### PR TITLE
fix(VolumeRendering): on switching dataset, ensure CTF preset valid

### DIFF
--- a/src/components/VolumePresets.vue
+++ b/src/components/VolumePresets.vue
@@ -1,9 +1,10 @@
 <script lang="ts">
-import { computed, defineComponent, watch } from 'vue';
+import { computed, defineComponent } from 'vue';
 import { PresetNameList } from '@/src/vtk/ColorMaps';
 import vtkColorMaps from '@kitware/vtk.js/Rendering/Core/ColorTransferFunction/ColorMaps';
 import ItemGroup from '@/src/components/ItemGroup.vue';
 import GroupableItem from '@/src/components/GroupableItem.vue';
+import { useVolumeColoringInitializer } from '@/src/composables/useVolumeColoringInitializer';
 import PersistentOverlay from './PersistentOverlay.vue';
 import { useCurrentImage } from '../composables/useCurrentImage';
 import useVolumeColoringStore from '../store/view-configs/volume-coloring';
@@ -26,17 +27,11 @@ export default defineComponent({
 
     const { currentImageID, currentImageData } = useCurrentImage();
 
+    useVolumeColoringInitializer(TARGET_VIEW_ID, currentImageID);
+
     const volumeColorConfig = computed(() =>
       volumeColoringStore.getConfig(TARGET_VIEW_ID, currentImageID.value)
     );
-
-    watch(volumeColorConfig, () => {
-      const imageID = currentImageID.value;
-      if (imageID && !volumeColorConfig.value) {
-        // creates a default color config
-        volumeColoringStore.updateConfig(TARGET_VIEW_ID, imageID, {});
-      }
-    });
 
     const colorTransferFunctionRef = computed(
       () => volumeColorConfig.value?.transferFunction

--- a/src/components/VolumeProperties.vue
+++ b/src/components/VolumeProperties.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
-import { computed, defineComponent, watch, ref } from 'vue';
+import { computed, defineComponent, ref } from 'vue';
+import { useVolumeColoringInitializer } from '@/src/composables/useVolumeColoringInitializer';
 import { useCurrentImage } from '../composables/useCurrentImage';
 import { CVRConfig } from '../types/views';
 import useVolumeColoringStore from '../store/view-configs/volume-coloring';
@@ -19,17 +20,11 @@ export default defineComponent({
 
     const { currentImageID } = useCurrentImage();
 
+    useVolumeColoringInitializer(TARGET_VIEW_ID, currentImageID);
+
     const volumeColorConfig = computed(() =>
       volumeColoringStore.getConfig(TARGET_VIEW_ID, currentImageID.value)
     );
-
-    watch(volumeColorConfig, () => {
-      const imageID = currentImageID.value;
-      if (imageID && !volumeColorConfig.value) {
-        // creates a default color config
-        volumeColoringStore.updateConfig(TARGET_VIEW_ID, imageID, {});
-      }
-    });
 
     // --- CVR --- //
 

--- a/src/store/view-configs/volume-coloring.ts
+++ b/src/store/view-configs/volume-coloring.ts
@@ -173,7 +173,7 @@ export const useVolumeColoringStore = defineStore('volumeColoring', () => {
   };
 
   /**
-   * Sets the view config defaults for a dataset.
+   * Sets all views' defaults for given dataset.
    * @param dataID
    * @param defaults
    */


### PR DESCRIPTION
Bug reproduction steps:
1. Load prostate sample
2. Switch to Rendering tab
3. Load Fetus sample

Error: VolumeRendering component would get an empty string preset, then fail to get a color transfer function from that.

This change initializes the volume-coloring store for a dataset in all components that depend on volume-coloring.