### PR TITLE
fix(crop): wait for DICOM image load

### DIFF
--- a/src/components/tools/crop/Crop3D.vue
+++ b/src/components/tools/crop/Crop3D.vue
@@ -50,8 +50,6 @@ export default defineComponent({
     const view = inject(VtkViewContext);
     if (!view) throw new Error('No VtkView');
 
-    console.log('whee');
-
     const { widgetManager } = view;
 
     const { imageId } = toRefs(props);

--- a/src/components/tools/crop/CropTool.vue
+++ b/src/components/tools/crop/CropTool.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { useViewStore } from '@/src/store/views';
 import { PropType, computed, defineComponent, toRefs } from 'vue';
-import { watchImmediate } from '@vueuse/core';
+import { wheneverImageLoaded } from '@/src/composables/wheneverImageLoaded';
 import { useCropStore } from '@/src/store/tools/crop';
 import { useToolStore } from '@/src/store/tools';
 import { Tools } from '@/src/store/tools/types';
@@ -29,7 +29,7 @@ export default defineComponent({
 
     const active = computed(() => toolStore.currentTool === Tools.Crop);
 
-    watchImmediate(imageId, (id) => {
+    wheneverImageLoaded(imageId, ({ id }) => {
       if (id && !(id in cropStore.croppingByImageID)) {
         cropStore.resetCropping(id);
       }

--- a/src/composables/wheneverImageLoaded.ts
+++ b/src/composables/wheneverImageLoaded.ts
@@ -1,0 +1,25 @@
+import { useImageStore } from '@/src/store/datasets-images';
+import { Maybe } from '@/src/types';
+import vtkImageData from '@kitware/vtk.js/Common/DataModel/ImageData';
+import { whenever } from '@vueuse/core';
+import { computed, Ref, WatchCallback } from 'vue';
+
+export function wheneverImageLoaded(
+  imageId: Ref<Maybe<string>>,
+  cb: WatchCallback<{ id: string; imageData: vtkImageData }>
+) {
+  const imageStore = useImageStore();
+  const hasImageData = computed(() => {
+    const id = imageId.value;
+    if (!id) return false;
+    return !!imageStore.dataIndex[id];
+  });
+
+  return whenever(hasImageData, (newVal, oldVal, onCleanup) => {
+    cb(
+      { id: imageId.value!, imageData: imageStore.dataIndex[imageId.value!] },
+      undefined,
+      onCleanup
+    );
+  });
+}


### PR DESCRIPTION
Cropping was failing on DICOM images because cropping was initialized before the DICOM data was fully loaded.