### PR TITLE
fix(updateFileMimeType): overwrite mimetype

### DIFF
--- a/src/io/import/processors/updateFileMimeType.ts
+++ b/src/io/import/processors/updateFileMimeType.ts
@@ -8,7 +8,7 @@ import { ImportHandler } from '@/src/io/import/common';
 const updateFileMimeType: ImportHandler = async (dataSource) => {
   let src = dataSource;
   const { fileSrc } = src;
-  if (fileSrc && fileSrc.fileType === '') {
+  if (fileSrc) {
     const mime = await getFileMimeType(fileSrc.file);
     if (mime) {
       src = {


### PR DESCRIPTION
Closes #663, and maybe #655.

Overwrites/normalizes the default OS-provided mimetype. Also ensures that the mime type is a supported mime type.

@PaulHax I think this should be fine, since if it's an unsupported mime type, setting to "null" won't change any logic. 

Should also be applied here: https://github.com/Kitware/VolView/pull/635/files#diff-7d267f00b6c6e1caa0952df237d876fce197c2048228c5f5bda7dd583232a40eR10