### PR TITLE
feat(global.css): increase tooltip background opacity

### DIFF
--- a/src/global.css
+++ b/src/global.css
@@ -23,6 +23,10 @@ body {
   border: thin solid rgb(var(--v-theme-on-surface-variant)) !important;
 }
 
+.v-tooltip .v-overlay__content {
+  background-color: rgba(255, 255, 255, 0.9) !important;
+}
+
 ul:not([class]),
 ol:not([class]) {
   padding-left: 20px;


### PR DESCRIPTION
For readability.

before
![Screenshot from 2024-10-21 15-06-41](https://github.com/user-attachments/assets/58f64368-3cd8-48a4-9764-faea3f868f01)

after
![Screenshot from 2024-10-21 15-06-52](https://github.com/user-attachments/assets/faf64aaf-4114-4c1b-8670-4527471b8435)
