### PR TITLE
Fix vue warning and potential js error in ScalarProbe.vue

### DIFF
--- a/src/components/tools/ScalarProbe.vue
+++ b/src/components/tools/ScalarProbe.vue
@@ -148,3 +148,5 @@ watch([currentImageID, sampleSet], () => {
   probeStore.clearProbeData();
 });
 </script>
+
+<template><slot></slot></template>

--- a/src/components/tools/ScalarProbe.vue
+++ b/src/components/tools/ScalarProbe.vue
@@ -95,7 +95,7 @@ watch(
   sampleSet,
   (samples) => {
     pointPicker.setPickList(
-      samples.length > 0 && samples[0] ? [samples[0].rep.actor] : []
+      samples.length > 0 && samples[0] && samples[0].rep ? [samples[0].rep.actor] : []
     );
   },
   { immediate: true }


### PR DESCRIPTION
the `ScalarProbe.vue` causes console warning:
![image](https://github.com/user-attachments/assets/f2664f99-ac71-4401-a5d6-02b02ba70cbc)

and causes this js error when switching Layout, for example from Quad View to Axial Only:
![image](https://github.com/user-attachments/assets/01695679-d0dc-4529-b23d-b954b3ceb800)
![image](https://github.com/user-attachments/assets/65e94946-a0db-4abb-8aaf-4dee38955d4f)

this PR fix above issues