### PR TITLE
fix(requestPool): increase pool size

### DIFF
--- a/src/core/streaming/requestPool.ts
+++ b/src/core/streaming/requestPool.ts
@@ -1,6 +1,6 @@
 import { Deferred, defer } from '@/src/utils';
 
-const DEFAULT_POOL_SIZE = 6;
+const DEFAULT_POOL_SIZE = 24;
 
 let nextId = 0;
 function getNextId() {


### PR DESCRIPTION
This just bumps up the request pool size to ensure we saturate the browser-level number of outgoing requests.