### PR TITLE
feat: improve error messages for file loading

### DIFF
--- a/src/actions/loadUserFiles.ts
+++ b/src/actions/loadUserFiles.ts
@@ -271,7 +271,7 @@ function loadDataSources(sources: DataSource[]) {
         const name = getDataSourceName(dataSource);
         // log error for debugging
         logError(error);
-        return `- ${name}: ${error.message}`;
+        return error.message ? `- ${name}: ${error.message}` : `- ${name}`;
       });
       const failedError = new Error(
         `These files failed to load:\n${errorMessages.join('\n')}`

--- a/src/io/import/processors/handleDicomStream.ts
+++ b/src/io/import/processors/handleDicomStream.ts
@@ -24,8 +24,14 @@ const handleDicomStream: ImportHandler = async (dataSource) => {
     });
 
   const readTags: ReadDicomTagsFunction = async (file) => {
-    const result = await readDicomTags(file, { webWorker: getWorker() });
-    return result.tags;
+    try {
+      const result = await readDicomTags(file, { webWorker: getWorker() });
+      return result.tags;
+    } catch (error) {
+      throw new Error(
+        `Failed to read DICOM tags from ${dataSource.uri}: ${error}`
+      );
+    }
   };
 
   const metaLoader = new DicomMetaLoader(fetcher, readTags);


### PR DESCRIPTION
For this bug: #733

now this:
![image](https://github.com/user-attachments/assets/5cee19f8-4740-4eca-9d9e-1659dbbb545d)


vs old message:
![image](https://github.com/user-attachments/assets/0f677135-9c26-40ac-82d8-e4ff6bc95f3a)
