### PR TITLE
fix(cachedStreamFetcher): avoid double download

### DIFF
--- a/src/core/streaming/cachedStreamFetcher.ts
+++ b/src/core/streaming/cachedStreamFetcher.ts
@@ -235,6 +235,9 @@ export class CachedStreamFetcher implements Fetcher {
         .then((result) => {
           if (!result.done) {
             this.chunks.push(result.value);
+          } else if (this.contentLength === null) {
+            // Entire stream finished but had no Content-Length header; treat full cache as total length
+            this.contentLength = this.size;
           }
           return result;
         })


### PR DESCRIPTION
When the entire stream finished but had no Content-Length header, treat full cache as total length.

Girder does not set Content-Length header in its response and we were fetching the entire stream twice.