### PR TITLE
fix(dicom): build valid DICOM when reading tags

### DIFF
--- a/src/core/streaming/streamingByteReader.ts
+++ b/src/core/streaming/streamingByteReader.ts
@@ -47,9 +47,10 @@ export default class StreamingByteReader {
     length: number,
     { peek = false } = {}
   ): Generator<undefined, Uint8Array, Uint8Array> {
-    if (length <= 0) {
+    if (length < 0) {
       throw new Error('Length must be a positive number');
     }
+    if (length === 0) return new Uint8Array();
 
     while (this.leftover.size < length) {
       this.leftover.pushEnd(yield);


### PR DESCRIPTION
- dicom parser now exposes element hooks
- extract implicit or explicit VR
- build an empty PixelData tag for metadata parsing