### PR TITLE
fix(windowing): no auto window level if user set already

### DIFF
--- a/src/components/tools/windowing/WindowLevelControls.vue
+++ b/src/components/tools/windowing/WindowLevelControls.vue
@@ -21,7 +21,9 @@ export default defineComponent({
     // Get the relevant view ids
     const viewIDs = computed(() =>
       viewStore.viewIDs.filter(
-        (viewID) => !!windowingStore.getConfig(viewID, currentImageID.value)
+        (viewID) =>
+          currentImageID.value &&
+          !!windowingStore.getConfig(viewID, currentImageID.value)
       )
     );
 
@@ -59,7 +61,8 @@ export default defineComponent({
       const imageID = currentImageID.value;
       if (!imageID || !viewID) return defaultWindowLevelConfig();
       return (
-        windowingStore.getConfig(viewID, imageID) ?? defaultWindowLevelConfig()
+        windowingStore.getConfig(viewID, imageID)?.value ??
+        defaultWindowLevelConfig()
       );
     });
 
@@ -84,7 +87,6 @@ export default defineComponent({
         }
 
         if (typeof selection === 'object') {
-          // It's a preset with { width, level }
           windowingStore.updateConfig(
             viewID,
             imageID,

--- a/src/components/tools/windowing/WindowLevelControls.vue
+++ b/src/components/tools/windowing/WindowLevelControls.vue
@@ -5,7 +5,7 @@ import useWindowingStore, {
   defaultWindowLevelConfig,
 } from '@/src/store/view-configs/windowing';
 import { useViewStore } from '@/src/store/views';
-import { WLAutoRanges, WLPresetsCT, WL_AUTO_DEFAULT } from '@/src/constants';
+import { WLAutoRanges, WLPresetsCT } from '@/src/constants';
 import { getWindowLevels, useDICOMStore } from '@/src/store/datasets-dicom';
 import { isDicomImage } from '@/src/utils/dataSelection';
 
@@ -16,7 +16,6 @@ export default defineComponent({
     const viewStore = useViewStore();
     const dicomStore = useDICOMStore();
     const panel = ref(['tags', 'presets', 'auto']);
-    const windowingDefaults = defaultWindowLevelConfig();
 
     // Get the relevant view ids
     const viewIDs = computed(() =>
@@ -48,10 +47,6 @@ export default defineComponent({
       return modality.value && ctTags.includes(modality.value.toLowerCase());
     });
 
-    const wlDefaults = computed(() => {
-      return { width: windowingDefaults.width, level: windowingDefaults.level };
-    });
-
     // --- UI Selection Management --- //
 
     type AutoRangeKey = keyof typeof WLAutoRanges;
@@ -61,39 +56,53 @@ export default defineComponent({
       // All views will have the same settings, just grab the first
       const viewID = viewIDs.value[0];
       const imageID = currentImageID.value;
-      if (!imageID || !viewID) return windowingDefaults;
-      return windowingStore.getConfig(viewID, imageID);
+      if (!imageID || !viewID) return defaultWindowLevelConfig();
+      return (
+        windowingStore.getConfig(viewID, imageID) ?? defaultWindowLevelConfig()
+      );
     });
 
-    const wlWidth = computed(
-      () => wlConfig.value?.width ?? wlDefaults.value.width
-    );
-    const wlLevel = computed(
-      () => wlConfig.value?.level ?? wlDefaults.value.level
-    );
+    const wlWidth = computed(() => wlConfig.value.width);
+    const wlLevel = computed(() => wlConfig.value.level);
 
     const wlOptions = computed({
       get() {
         const config = wlConfig.value;
-        const { width, level } = config?.preset || wlDefaults.value;
-        const { width: defaultWidth, level: defaultLevel } = wlDefaults.value;
-        if (width !== defaultWidth && level !== defaultLevel) {
-          return { width: wlWidth.value, level: wlLevel.value };
+        if (config.useAuto) {
+          return config.auto;
         }
-        return config?.auto || WL_AUTO_DEFAULT;
+        // Otherwise, a specific W/L is active (from preset or manual adjustment).
+        return { width: wlWidth.value, level: wlLevel.value };
       },
       set(selection: AutoRangeKey | PresetValue) {
         const imageID = currentImageID.value;
         // All views will be synchronized, just set the first
         const viewID = viewIDs.value[0];
-        if (imageID && viewID) {
-          const useAuto = typeof selection !== 'object';
-          const newValue = {
-            preset: useAuto ? wlDefaults.value : selection,
-            auto: useAuto ? selection : WL_AUTO_DEFAULT,
-          };
-          windowingStore.updateConfig(viewID, imageID, newValue);
-          windowingStore.resetWindowLevel(viewID, imageID);
+        if (!imageID || !viewID) {
+          return;
+        }
+        if (typeof selection === 'object') {
+          // It's a preset with { width, level }
+          windowingStore.updateConfig(
+            viewID,
+            imageID,
+            {
+              width: selection.width,
+              level: selection.level,
+              useAuto: false,
+            },
+            true
+          );
+        } else {
+          windowingStore.updateConfig(
+            viewID,
+            imageID,
+            {
+              auto: selection,
+              useAuto: true,
+            },
+            true
+          );
         }
       },
     });

--- a/src/components/tools/windowing/WindowLevelControls.vue
+++ b/src/components/tools/windowing/WindowLevelControls.vue
@@ -1,7 +1,8 @@
 <script lang="ts">
 import { computed, defineComponent, ref } from 'vue';
 import { useCurrentImage } from '@/src/composables/useCurrentImage';
-import useWindowingStore, {
+import {
+  useWindowingStore,
   defaultWindowLevelConfig,
 } from '@/src/store/view-configs/windowing';
 import { useViewStore } from '@/src/store/views';

--- a/src/components/tools/windowing/WindowLevelControls.vue
+++ b/src/components/tools/windowing/WindowLevelControls.vue
@@ -81,6 +81,7 @@ export default defineComponent({
         if (!imageID || !viewID) {
           return;
         }
+
         if (typeof selection === 'object') {
           // It's a preset with { width, level }
           windowingStore.updateConfig(
@@ -89,21 +90,20 @@ export default defineComponent({
             {
               width: selection.width,
               level: selection.level,
-              useAuto: false,
             },
             true
           );
-        } else {
-          windowingStore.updateConfig(
-            viewID,
-            imageID,
-            {
-              auto: selection,
-              useAuto: true,
-            },
-            true
-          );
+          return;
         }
+
+        windowingStore.updateConfig(
+          viewID,
+          imageID,
+          {
+            auto: selection,
+          },
+          true
+        );
       },
     });
 

--- a/src/composables/useWindowingConfig.ts
+++ b/src/composables/useWindowingConfig.ts
@@ -1,4 +1,4 @@
-import useWindowingStore from '@/src/store/view-configs/windowing';
+import { useWindowingStore } from '@/src/store/view-configs/windowing';
 import { Maybe } from '@/src/types';
 import type { Vector2 } from '@kitware/vtk.js/types';
 import { MaybeRef, unref, computed } from 'vue';

--- a/src/composables/useWindowingConfig.ts
+++ b/src/composables/useWindowingConfig.ts
@@ -15,13 +15,13 @@ export function useWindowingConfig(
     if (!imageIdVal) return undefined;
     const viewIdVal = unref(viewID);
     if (!viewIdVal) return undefined;
-    return store.getConfig(viewIdVal, imageIdVal);
+    return store.getConfig(viewIdVal, imageIdVal).value;
   });
 
   const generateComputed = (prop: 'width' | 'level') => {
     return computed({
       get: () => {
-        return config.value?.value?.[prop] ?? 0;
+        return config.value?.[prop] ?? 0;
       },
       set: (val) => {
         const imageIdVal = unref(imageID);

--- a/src/composables/useWindowingConfig.ts
+++ b/src/composables/useWindowingConfig.ts
@@ -2,12 +2,14 @@ import useWindowingStore from '@/src/store/view-configs/windowing';
 import { Maybe } from '@/src/types';
 import type { Vector2 } from '@kitware/vtk.js/types';
 import { MaybeRef, unref, computed } from 'vue';
+import { useImageStatsStore } from '@/src/store/image-stats';
 
 export function useWindowingConfig(
   viewID: MaybeRef<string>,
   imageID: MaybeRef<Maybe<string>>
 ) {
   const store = useWindowingStore();
+  const imageStatsStore = useImageStatsStore();
   const config = computed(() => store.getConfig(unref(viewID), unref(imageID)));
 
   const generateComputed = (prop: 'width' | 'level') => {
@@ -22,9 +24,12 @@ export function useWindowingConfig(
   };
 
   const range = computed((): Vector2 => {
-    const { min, max } = config.value ?? {};
-    if (min == null || max == null) return [0, 1];
-    return [min, max];
+    const imageIdVal = unref(imageID);
+    if (!imageIdVal) return [0, 1];
+    const stats = imageStatsStore.stats[imageIdVal];
+    if (!stats || stats.scalarMin == null || stats.scalarMax == null)
+      return [0, 1];
+    return [stats.scalarMin, stats.scalarMax];
   });
 
   return {

--- a/src/composables/useWindowingConfig.ts
+++ b/src/composables/useWindowingConfig.ts
@@ -10,11 +10,19 @@ export function useWindowingConfig(
 ) {
   const store = useWindowingStore();
   const imageStatsStore = useImageStatsStore();
-  const config = computed(() => store.getConfig(unref(viewID), unref(imageID)));
+  const config = computed(() => {
+    const imageIdVal = unref(imageID);
+    if (!imageIdVal) return undefined;
+    const viewIdVal = unref(viewID);
+    if (!viewIdVal) return undefined;
+    return store.getConfig(viewIdVal, imageIdVal);
+  });
 
   const generateComputed = (prop: 'width' | 'level') => {
     return computed({
-      get: () => config.value?.[prop] ?? 0,
+      get: () => {
+        return config.value?.value?.[prop] ?? 0;
+      },
       set: (val) => {
         const imageIdVal = unref(imageID);
         if (!imageIdVal || val == null) return;

--- a/src/composables/useWindowingConfig.ts
+++ b/src/composables/useWindowingConfig.ts
@@ -16,7 +16,7 @@ export function useWindowingConfig(
       set: (val) => {
         const imageIdVal = unref(imageID);
         if (!imageIdVal || val == null) return;
-        store.updateConfig(unref(viewID), imageIdVal, { [prop]: val });
+        store.updateConfig(unref(viewID), imageIdVal, { [prop]: val }, true);
       },
     });
   };

--- a/src/composables/useWindowingConfigInitializer.ts
+++ b/src/composables/useWindowingConfigInitializer.ts
@@ -1,70 +1,14 @@
 import { MaybeRef, computed, unref, watch } from 'vue';
-import * as Comlink from 'comlink';
-import vtkDataArray from '@kitware/vtk.js/Common/Core/DataArray';
-import { computedAsync, watchImmediate } from '@vueuse/core';
+import { watchImmediate } from '@vueuse/core';
 import { useImage } from '@/src/composables/useCurrentImage';
 import { useWindowingConfig } from '@/src/composables/useWindowingConfig';
-import { WLAutoRanges, WL_AUTO_DEFAULT, WL_HIST_BINS } from '@/src/constants';
+import { WL_AUTO_DEFAULT } from '@/src/constants';
 import { getWindowLevels, useDICOMStore } from '@/src/store/datasets-dicom';
-import { vtkFieldRef } from '@/src/core/vtk/vtkFieldRef';
 import useWindowingStore from '@/src/store/view-configs/windowing';
 import { Maybe } from '@/src/types';
 import { useResetViewsEvents } from '@/src/components/tools/ResetViews.vue';
 import { isDicomImage } from '@/src/utils/dataSelection';
-import { HistogramWorker } from '@/src/utils/histogram.worker';
-
-function useAutoRangeValues(imageID: MaybeRef<Maybe<string>>) {
-  const { imageData, isLoading: isImageLoading } = useImage(imageID);
-
-  const worker = Comlink.wrap<HistogramWorker>(
-    new Worker(new URL('@/src/utils/histogram.worker.ts', import.meta.url), {
-      type: 'module',
-    })
-  );
-
-  const scalars = vtkFieldRef(
-    computed(() => imageData.value?.getPointData()),
-    'scalars'
-  );
-
-  const autoRangeValues = computedAsync(async () => {
-    if (isImageLoading.value || !scalars.value) {
-      return {};
-    }
-
-    // Pre-compute the auto-range values
-    const scalarData = scalars.value.getData();
-    // Assumes all data is one component
-    const { min, max } = vtkDataArray.fastComputeRange(
-      scalarData as number[],
-      0,
-      1
-    );
-    const hist = await worker.histogram(scalarData, [min, max], WL_HIST_BINS);
-    const cumulativeHist = hist.reduce((acc, val, idx) => {
-      const prev = idx !== 0 ? acc[idx - 1] : 0;
-      acc.push(val + prev);
-      return acc;
-    }, [] as number[]);
-
-    const width = (max - min + 1) / WL_HIST_BINS;
-    return Object.fromEntries(
-      Object.entries(WLAutoRanges).map(([key, value]) => {
-        const startIdx = cumulativeHist.findIndex(
-          (v: number) => v >= value * 0.01 * scalarData.length
-        );
-        const endIdx = cumulativeHist.findIndex(
-          (v: number) => v >= (1 - value * 0.01) * scalarData.length
-        );
-        const start = Math.max(min, min + width * startIdx);
-        const end = Math.min(max, min + width * endIdx + width);
-        return [key, [start, end]];
-      })
-    );
-  }, {});
-
-  return { autoRangeValues };
-}
+import { useImageStatsStore } from '@/src/store/image-stats';
 
 export function useWindowingConfigInitializer(
   viewID: MaybeRef<string>,
@@ -72,15 +16,11 @@ export function useWindowingConfigInitializer(
 ) {
   const { imageData } = useImage(imageID);
   const dicomStore = useDICOMStore();
-
-  const scalarRange = vtkFieldRef(
-    computed(() => imageData.value?.getPointData()?.getScalars()),
-    'range'
-  );
+  const imageStatsStore = useImageStatsStore();
 
   const store = useWindowingStore();
   const { config: windowConfig } = useWindowingConfig(viewID, imageID);
-  const { autoRangeValues } = useAutoRangeValues(imageID);
+  const autoRangeValues = imageStatsStore.getAutoRangeValues(imageID);
   const useAuto = computed(() => windowConfig.value?.useAuto);
   const autoRange = computed(() => windowConfig.value?.auto || WL_AUTO_DEFAULT);
 
@@ -93,13 +33,6 @@ export function useWindowingConfigInitializer(
       }
     }
     return undefined;
-  });
-
-  watchImmediate(scalarRange, (range) => {
-    const imageIdVal = unref(imageID);
-    const viewIdVal = unref(viewID);
-    if (!range || !imageIdVal || !viewIdVal) return;
-    store.updateConfig(viewIdVal, imageIdVal, { min: range[0], max: range[1] });
   });
 
   function updateConfigFromAutoRangeValues() {
@@ -163,11 +96,16 @@ export function useWindowingConfigInitializer(
       return;
     }
     const range = autoRangeValues.value[autoRange.value];
+    if (!range) {
+      // This can happen during initial loading and range not computed yet.
+      return;
+    }
     const width = range[1] - range[0];
     const level = (range[1] + range[0]) / 2;
     store.updateConfig(viewIdVal, imageIdVal, {
       width,
       level,
+      useAuto: true,
     });
   });
 

--- a/src/composables/useWindowingConfigInitializer.ts
+++ b/src/composables/useWindowingConfigInitializer.ts
@@ -46,10 +46,10 @@ export function useWindowingConfigInitializer(
       });
     }
 
-    const jsonWidthLevel = store.runtimeConfigWindowLevel;
-    if (jsonWidthLevel) {
+    const widthLevel = store.runtimeConfigWindowLevel;
+    if (widthLevel) {
       store.updateConfig(viewIdVal, imageIdVal, {
-        ...jsonWidthLevel,
+        ...widthLevel,
       });
     }
   }

--- a/src/composables/useWindowingConfigInitializer.ts
+++ b/src/composables/useWindowingConfigInitializer.ts
@@ -57,11 +57,12 @@ export function useWindowingConfigInitializer(
   watchImmediate(
     [imageData],
     () => {
-      if (!imageData.value) {
+      const imageIdValue = unref(imageID);
+      if (!imageData.value || !imageIdValue) {
         return;
       }
 
-      const config = store.getConfig(unref(viewID), unref(imageID));
+      const config = store.getConfig(unref(viewID), imageIdValue).value;
       if (config?.userTriggered) {
         return;
       }

--- a/src/composables/useWindowingConfigInitializer.ts
+++ b/src/composables/useWindowingConfigInitializer.ts
@@ -152,8 +152,8 @@ export function useWindowingConfigInitializer(
     { deep: true }
   );
 
-  watch([useAuto, autoRange], ([gate, percentile]) => {
-    if (!gate) {
+  watch([useAuto, autoRange, autoRangeValues], () => {
+    if (!useAuto.value) {
       return;
     }
     const image = imageData.value;
@@ -162,7 +162,7 @@ export function useWindowingConfigInitializer(
     if (imageIdVal == null || windowConfig.value == null || !image) {
       return;
     }
-    const range = autoRangeValues.value[percentile];
+    const range = autoRangeValues.value[autoRange.value];
     const width = range[1] - range[0];
     const level = (range[1] + range[0]) / 2;
     store.updateConfig(viewIdVal, imageIdVal, {

--- a/src/core/streaming/dicomChunkImage.ts
+++ b/src/core/streaming/dicomChunkImage.ts
@@ -363,6 +363,7 @@ export default class DicomChunkImage
       const newMin = rangeAlreadyInitialized ? Math.min(min, curRange[0]) : min;
       const newMax = rangeAlreadyInitialized ? Math.max(max, curRange[1]) : max;
       scalars.setRange({ min: newMin, max: newMax }, comp);
+      scalars.modified(); // so window level watchers will trigger
     }
 
     chunk.setUserData(DATA_RANGE_KEY, chunkDataRange);

--- a/src/core/streaming/dicomChunkImage.ts
+++ b/src/core/streaming/dicomChunkImage.ts
@@ -363,7 +363,7 @@ export default class DicomChunkImage
       const newMin = rangeAlreadyInitialized ? Math.min(min, curRange[0]) : min;
       const newMax = rangeAlreadyInitialized ? Math.max(max, curRange[1]) : max;
       scalars.setRange({ min: newMin, max: newMax }, comp);
-      scalars.modified(); // so window level watchers will trigger
+      scalars.modified(); // so image-stats will trigger update of range
     }
 
     chunk.setUserData(DATA_RANGE_KEY, chunkDataRange);

--- a/src/core/vtk/vtkFieldRef.ts
+++ b/src/core/vtk/vtkFieldRef.ts
@@ -81,7 +81,7 @@ export function vtkFieldRef<T extends Maybe<vtkObject>>(
 
     getter = () => {
       const value = _getter.value?.();
-      // If the value is an array, create a new reference to avoid mutation issues
+      // create a new reference to trigger update
       if (Array.isArray(value)) {
         lastValue = [...value];
         lastValueIsArray = true;
@@ -108,7 +108,7 @@ export function vtkFieldRef<T extends Maybe<vtkObject>>(
     const originalGetter = fieldNameOrFactory.get;
     getter = () => {
       const value = originalGetter();
-      // If the value is an array, create a new reference to avoid mutation issues
+      // create a new reference to trigger update
       if (Array.isArray(value)) {
         lastValue = [...value];
         lastValueIsArray = true;

--- a/src/core/vtk/vtkFieldRef.ts
+++ b/src/core/vtk/vtkFieldRef.ts
@@ -58,6 +58,8 @@ export function vtkFieldRef<T extends Maybe<vtkObject>>(
 ): any {
   let getter: () => any;
   let setter: (v: any) => boolean | undefined;
+  let lastValue: any;
+  let lastValueIsArray = false;
 
   if (typeof fieldNameOrFactory === 'string') {
     const getterName = `get${capitalize(fieldNameOrFactory)}` as keyof T;
@@ -77,7 +79,19 @@ export function vtkFieldRef<T extends Maybe<vtkObject>>(
       return val ? setterName in val : false;
     });
 
-    getter = () => _getter.value?.();
+    getter = () => {
+      const value = _getter.value?.();
+      // If the value is an array, create a new reference to avoid mutation issues
+      if (Array.isArray(value)) {
+        lastValue = [...value];
+        lastValueIsArray = true;
+        return lastValue;
+      }
+      lastValue = value;
+      lastValueIsArray = false;
+      return value;
+    };
+
     setter = (v: any) => {
       const set = _setter.value;
       if (!notNull.value) return false;
@@ -91,7 +105,19 @@ export function vtkFieldRef<T extends Maybe<vtkObject>>(
       return set(v);
     };
   } else {
-    getter = fieldNameOrFactory.get;
+    const originalGetter = fieldNameOrFactory.get;
+    getter = () => {
+      const value = originalGetter();
+      // If the value is an array, create a new reference to avoid mutation issues
+      if (Array.isArray(value)) {
+        lastValue = [...value];
+        lastValueIsArray = true;
+        return lastValue;
+      }
+      lastValue = value;
+      lastValueIsArray = false;
+      return value;
+    };
     setter = fieldNameOrFactory.set;
   }
 
@@ -125,6 +151,27 @@ export function vtkFieldRef<T extends Maybe<vtkObject>>(
 
   const onModified = batchForNextTask(() => {
     if (unref(obj)?.isDeleted()) return;
+
+    // Special handling for array values that might have been mutated
+    if (lastValueIsArray) {
+      const currentValue = getter();
+      if (Array.isArray(currentValue)) {
+        const previousValue = lastValue;
+        // Check if array contents changed
+        if (
+          previousValue.length !== currentValue.length ||
+          previousValue.some(
+            (val: any, idx: number) => val !== currentValue[idx]
+          )
+        ) {
+          // Values changed, trigger the ref
+          triggerRef(ref);
+          return;
+        }
+      }
+    }
+
+    // Always trigger for non-array values
     triggerRef(ref);
   });
 

--- a/src/io/import/processors/restoreStateFile.ts
+++ b/src/io/import/processors/restoreStateFile.ts
@@ -359,9 +359,9 @@ const restoreStateFile: ImportHandler = async (dataSource, context) => {
     let manifest: Manifest;
     try {
       manifest = ManifestSchema.parse(migrated);
-    } catch (_) {
+    } catch (e) {
       return asErrorResult(
-        new Error('Unsupported state file schema or version'),
+        new Error(`Unsupported state file schema or version: ${e}`),
         dataSource
       );
     }

--- a/src/io/state-file/index.ts
+++ b/src/io/state-file/index.ts
@@ -12,7 +12,7 @@ import { retypeFile } from '../io';
 import { ARCHIVE_FILE_TYPES } from '../mimeTypes';
 
 export const MANIFEST = 'manifest.json';
-export const MANIFEST_VERSION = '5.0.0';
+export const MANIFEST_VERSION = '5.0.1';
 
 export async function serialize() {
   const datasetStore = useDatasetStore();

--- a/src/io/state-file/schema.ts
+++ b/src/io/state-file/schema.ts
@@ -134,8 +134,6 @@ type AutoRangeKeys = keyof typeof WLAutoRanges;
 const WindowLevelConfig = z.object({
   width: z.number(),
   level: z.number(),
-  min: z.number(),
-  max: z.number(),
   auto: z.string() as z.ZodType<AutoRangeKeys>,
   useAuto: z.boolean().optional(),
   userTriggered: z.boolean().optional(),

--- a/src/io/state-file/schema.ts
+++ b/src/io/state-file/schema.ts
@@ -131,13 +131,29 @@ const Vector3 = z.tuple([
 ]) satisfies z.ZodType<Vector3>;
 
 type AutoRangeKeys = keyof typeof WLAutoRanges;
-const WindowLevelConfig = z.object({
-  width: z.number(),
-  level: z.number(),
-  auto: z.string() as z.ZodType<AutoRangeKeys>,
-  useAuto: z.boolean().optional(),
-  userTriggered: z.boolean().optional(),
-}) satisfies z.ZodType<WindowLevelConfig>;
+const WindowLevelConfig = z
+  .object({
+    width: z.number().optional(),
+    level: z.number().optional(),
+    auto: z.string() as z.ZodType<AutoRangeKeys>,
+    useAuto: z.boolean().optional(),
+    userTriggered: z.boolean().optional(),
+  })
+  .refine(
+    (data) => {
+      // If useAuto is false, width and level must be present
+      if (
+        data.useAuto === false &&
+        (data.width === undefined || data.level === undefined)
+      ) {
+        return false;
+      }
+      return true;
+    },
+    {
+      message: 'width and level are required when useAuto is false',
+    }
+  ) satisfies z.ZodType<WindowLevelConfig>;
 
 const SliceConfig = z.object({
   slice: z.number(),

--- a/src/io/state-file/schema.ts
+++ b/src/io/state-file/schema.ts
@@ -137,7 +137,8 @@ const WindowLevelConfig = z.object({
   min: z.number(),
   max: z.number(),
   auto: z.string() as z.ZodType<AutoRangeKeys>,
-  preset: z.object({ width: z.number(), level: z.number() }),
+  useAuto: z.boolean().optional(),
+  userTriggered: z.boolean().optional(),
 }) satisfies z.ZodType<WindowLevelConfig>;
 
 const SliceConfig = z.object({

--- a/src/store/image-stats.ts
+++ b/src/store/image-stats.ts
@@ -1,0 +1,224 @@
+import { defineStore } from 'pinia';
+import { reactive, watch, computed, MaybeRef, unref } from 'vue';
+import * as Comlink from 'comlink';
+import vtkDataArray from '@kitware/vtk.js/Common/Core/DataArray';
+import { vtkFieldRef } from '@/src/core/vtk/vtkFieldRef';
+import { WLAutoRanges, WL_HIST_BINS } from '@/src/constants';
+import { HistogramWorker } from '@/src/utils/histogram.worker';
+import { Maybe } from '@/src/types';
+import { useImage } from '@/src/composables/useCurrentImage';
+import { useImageCacheStore } from './image-cache';
+import { useMessageStore } from './messages';
+
+export type ImageStats = {
+  scalarMin: number;
+  scalarMax: number;
+  autoRangeValues?: Record<string, [number, number]>;
+};
+
+// Helper function to compute auto range values, similar to the original useAutoRangeValues
+async function computeAutoRangeValues(
+  imageData: ReturnType<typeof useImage>['imageData']['value'],
+  isImageLoading: ReturnType<typeof useImage>['isLoading']['value']
+): Promise<Record<string, [number, number]>> {
+  if (isImageLoading || !imageData) {
+    return {};
+  }
+
+  const scalars = imageData.getPointData()?.getScalars();
+  if (!scalars) {
+    return {};
+  }
+
+  const worker = Comlink.wrap<HistogramWorker>(
+    new Worker(new URL('@/src/utils/histogram.worker.ts', import.meta.url), {
+      type: 'module',
+    })
+  );
+
+  const scalarData = scalars.getData() as number[];
+  const { min, max } = vtkDataArray.fastComputeRange(scalarData, 0, 1);
+  const hist = await worker.histogram(scalarData, [min, max], WL_HIST_BINS);
+  worker[Comlink.releaseProxy]();
+
+  const cumulativeHist: number[] = [];
+  hist.reduce((acc, val) => {
+    const currentSum = acc + val;
+    cumulativeHist.push(currentSum);
+    return currentSum;
+  }, 0);
+
+  const width = (max - min + 1) / WL_HIST_BINS;
+  const totalCount = scalarData.length;
+
+  return Object.fromEntries(
+    Object.entries(WLAutoRanges).map(([key, percentage]) => {
+      const lowerBound = percentage * 0.01 * totalCount;
+      const upperBound = (1 - percentage * 0.01) * totalCount;
+
+      const startIdx = cumulativeHist.findIndex((v) => v >= lowerBound);
+      const endIdx = cumulativeHist.findIndex((v) => v >= upperBound);
+
+      const start = Math.max(min, min + width * startIdx);
+      const end = Math.min(max, min + width * (endIdx + 1)); // Adjusted end calculation
+      return [key, [start, end] as [number, number]];
+    })
+  );
+}
+
+export const useImageStatsStore = defineStore('image-stats', () => {
+  const stats = reactive<Record<string, ImageStats>>({});
+  const imageCacheStore = useImageCacheStore();
+  const messageStore = useMessageStore();
+
+  const scalarRangeWatchers: Record<string, () => void> = {};
+  const autoRangeComputations: Record<
+    string,
+    Promise<Record<string, [number, number]>>
+  > = {};
+
+  const internalSetScalarRange = (
+    imageID: string,
+    min: number,
+    max: number
+  ) => {
+    stats[imageID] = {
+      ...stats[imageID], // preserve existing autoRangeValues
+      scalarMin: min,
+      scalarMax: max,
+    };
+  };
+
+  const internalSetAutoRangeValues = (
+    imageID: string,
+    autoValues: Record<string, [number, number]>
+  ) => {
+    stats[imageID] = {
+      ...(stats[imageID] ?? { scalarMin: 0, scalarMax: 0 }),
+      autoRangeValues: autoValues,
+    };
+  };
+
+  const internalRemoveStats = (imageID: string) => {
+    delete stats[imageID];
+  };
+
+  const setupImageWatcher = (id: string) => {
+    if (scalarRangeWatchers[id]) {
+      scalarRangeWatchers[id]();
+    }
+
+    const { imageData, isLoading: isImageLoading } = useImage(
+      computed(() => id)
+    );
+
+    const activeScalars = computed(() =>
+      imageData.value?.getPointData()?.getScalars()
+    );
+    const scalarRange = vtkFieldRef(activeScalars, 'range');
+
+    scalarRangeWatchers[id] = watch(
+      scalarRange,
+      (range) => {
+        if (imageData.value && range) {
+          internalSetScalarRange(id, range[0], range[1]);
+        } else {
+          internalRemoveStats(id);
+        }
+      },
+      { immediate: true }
+    );
+
+    const updateAutoRangeValuesIfNeeded = () => {
+      const currentImageData = imageData.value;
+      const currentIsLoading = isImageLoading.value;
+
+      if (!currentIsLoading && currentImageData) {
+        if (id in autoRangeComputations) {
+          return;
+        }
+        autoRangeComputations[id] = computeAutoRangeValues(
+          currentImageData,
+          currentIsLoading
+        );
+
+        autoRangeComputations[id]
+          .then((autoValues) => {
+            if (imageCacheStore.imageIds.includes(id)) {
+              internalSetAutoRangeValues(id, autoValues);
+            }
+          })
+          .catch((error) => {
+            console.error(
+              `[ImageStatsStore] Auto range computation for image ${id} FAILED:`,
+              error
+            );
+            messageStore.addError(
+              `Auto range computation failed for image ${id}`,
+              error instanceof Error ? error : String(error)
+            );
+            if (imageCacheStore.imageIds.includes(id)) {
+              internalSetAutoRangeValues(id, {});
+            }
+          })
+          .finally(() => {
+            delete autoRangeComputations[id];
+          });
+      } else if (!currentImageData) {
+        internalSetAutoRangeValues(id, {});
+        if (id in autoRangeComputations) {
+          delete autoRangeComputations[id];
+        }
+      }
+    };
+
+    watch(
+      [imageData, isImageLoading],
+      () => {
+        updateAutoRangeValuesIfNeeded();
+      },
+      { immediate: true, deep: false }
+    );
+  };
+
+  const cleanupImageWatcher = (id: string) => {
+    internalRemoveStats(id);
+    if (scalarRangeWatchers[id]) {
+      scalarRangeWatchers[id]();
+      delete scalarRangeWatchers[id];
+    }
+    delete autoRangeComputations[id];
+  };
+
+  watch(
+    () => [...imageCacheStore.imageIds],
+    (currentImageIds, previousImageIds = []) => {
+      const addedIds = currentImageIds.filter(
+        (id) => !previousImageIds.includes(id)
+      );
+      const removedIds = previousImageIds.filter(
+        (id) => !currentImageIds.includes(id)
+      );
+
+      removedIds.forEach(cleanupImageWatcher);
+      addedIds.forEach(setupImageWatcher);
+    },
+    { immediate: true }
+  );
+
+  // Getter for autoRangeValues, returning a computed ref
+  const getAutoRangeValues = (imageID: MaybeRef<Maybe<string>>) => {
+    return computed(() => {
+      const id = unref(imageID); // Use unref to get value from MaybeRef
+      if (id && stats[id]) {
+        return stats[id].autoRangeValues ?? {};
+      }
+      return {};
+    });
+  };
+
+  return {
+    stats,
+    getAutoRangeValues, // Expose the getter
+  };
+});

--- a/src/store/image-stats.ts
+++ b/src/store/image-stats.ts
@@ -16,7 +16,6 @@ export type ImageStats = {
   autoRangeValues?: Record<string, [number, number]>;
 };
 
-// Helper function to compute auto range values, similar to the original useAutoRangeValues
 async function computeAutoRangeValues(
   imageData: ReturnType<typeof useImage>['imageData']['value'],
   isImageLoading: ReturnType<typeof useImage>['isLoading']['value']
@@ -83,7 +82,7 @@ export const useImageStatsStore = defineStore('image-stats', () => {
     max: number
   ) => {
     stats[imageID] = {
-      ...stats[imageID], // preserve existing autoRangeValues
+      ...stats[imageID],
       scalarMin: min,
       scalarMax: max,
     };
@@ -206,10 +205,9 @@ export const useImageStatsStore = defineStore('image-stats', () => {
     { immediate: true }
   );
 
-  // Getter for autoRangeValues, returning a computed ref
   const getAutoRangeValues = (imageID: MaybeRef<Maybe<string>>) => {
     return computed(() => {
-      const id = unref(imageID); // Use unref to get value from MaybeRef
+      const id = unref(imageID);
       if (id && stats[id]) {
         return stats[id].autoRangeValues ?? {};
       }
@@ -219,6 +217,6 @@ export const useImageStatsStore = defineStore('image-stats', () => {
 
   return {
     stats,
-    getAutoRangeValues, // Expose the getter
+    getAutoRangeValues,
   };
 });

--- a/src/store/image-stats.ts
+++ b/src/store/image-stats.ts
@@ -2,6 +2,7 @@ import { defineStore } from 'pinia';
 import { reactive, watch, computed, MaybeRef, unref } from 'vue';
 import * as Comlink from 'comlink';
 import vtkDataArray from '@kitware/vtk.js/Common/Core/DataArray';
+import vtkImageData from '@kitware/vtk.js/Common/DataModel/ImageData';
 import { vtkFieldRef } from '@/src/core/vtk/vtkFieldRef';
 import { WLAutoRanges, WL_HIST_BINS } from '@/src/constants';
 import { HistogramWorker } from '@/src/utils/histogram.worker';
@@ -17,8 +18,8 @@ export type ImageStats = {
 };
 
 async function computeAutoRangeValues(
-  imageData: ReturnType<typeof useImage>['imageData']['value'],
-  isImageLoading: ReturnType<typeof useImage>['isLoading']['value']
+  imageData: vtkImageData,
+  isImageLoading: boolean
 ): Promise<Record<string, [number, number]>> {
   if (isImageLoading || !imageData) {
     return {};

--- a/src/store/view-configs.ts
+++ b/src/store/view-configs.ts
@@ -1,7 +1,7 @@
 import { defineStore } from 'pinia';
 
 import useViewSliceStore from './view-configs/slicing';
-import useWindowingStore from './view-configs/windowing';
+import { useWindowingStore } from './view-configs/windowing';
 import useLayerColoringStore from './view-configs/layers';
 import useViewCameraStore from './view-configs/camera';
 import useVolumeColoringStore from './view-configs/volume-coloring';

--- a/src/store/view-configs/common.ts
+++ b/src/store/view-configs/common.ts
@@ -1,53 +1,10 @@
 import { DoubleKeyRecord } from '@/src/utils/doubleKeyRecord';
 import { StateFile, ViewConfig } from '../../io/state-file/schema';
-import {
-  CameraConfig,
-  LayersConfig,
-  SegmentGroupConfig,
-  SliceConfig,
-  VolumeColorConfig,
-  WindowLevelConfig,
-} from './types';
 import { ensureDefault } from '../../utils';
-
-type SubViewConfig =
-  | CameraConfig
-  | SliceConfig
-  | VolumeColorConfig
-  | WindowLevelConfig
-  | LayersConfig
-  | SegmentGroupConfig;
-
-type ViewConfigGetter = (
-  viewID: string,
-  dataID: string
-) => SubViewConfig | undefined;
 
 type ViewConfigStateKey = keyof ViewConfig;
 
-export const serializeViewConfig = <K extends ViewConfigStateKey>(
-  stateFile: StateFile,
-  configGetter: ViewConfigGetter,
-  viewConfigStateKey: K
-) => {
-  const dataIDs = stateFile.manifest.datasets.map((dataset) => dataset.id);
-  const { views } = stateFile.manifest;
-
-  views.forEach((view) => {
-    dataIDs.forEach((dataID) => {
-      const { config } = view;
-
-      const viewConfig = configGetter(view.id, dataID);
-      if (viewConfig !== undefined) {
-        const configForData = ensureDefault(dataID, config, {} as ViewConfig);
-
-        configForData[viewConfigStateKey] = viewConfig as ViewConfig[K];
-      }
-    });
-  });
-};
-
-export const serializeViewConfigV2 = <
+const serializeViewConfig = <
   K extends ViewConfigStateKey,
   V extends ViewConfig[K]
 >(
@@ -85,6 +42,6 @@ export const createViewConfigSerializer = <
   viewConfigStateKey: K
 ) => {
   return (stateFile: StateFile) => {
-    serializeViewConfigV2(stateFile, viewConfigs, viewConfigStateKey);
+    serializeViewConfig(stateFile, viewConfigs, viewConfigStateKey);
   };
 };

--- a/src/store/view-configs/types.ts
+++ b/src/store/view-configs/types.ts
@@ -38,8 +38,6 @@ export interface VolumeColorConfig {
 export interface WindowLevelConfig {
   width: number;
   level: number;
-  min: number; // data range min
-  max: number; // data range max
   auto: keyof typeof WLAutoRanges; // User-selected percentile range
   useAuto?: boolean; // Whether to use the percentage histogram range
   userTriggered?: boolean; // Whether the user has changed the window/level

--- a/src/store/view-configs/types.ts
+++ b/src/store/view-configs/types.ts
@@ -36,8 +36,8 @@ export interface VolumeColorConfig {
 }
 
 export interface WindowLevelConfig {
-  width: number;
-  level: number;
+  width?: number;
+  level?: number;
   auto: keyof typeof WLAutoRanges; // User-selected percentile range
   useAuto?: boolean; // Whether to use the percentage histogram range
   userTriggered?: boolean; // Whether the user has changed the window/level

--- a/src/store/view-configs/types.ts
+++ b/src/store/view-configs/types.ts
@@ -41,11 +41,8 @@ export interface WindowLevelConfig {
   min: number; // data range min
   max: number; // data range max
   auto: keyof typeof WLAutoRanges; // User-selected percentile range
-  preset: {
-    // User-selected preset value, if any
-    width: number;
-    level: number;
-  };
+  useAuto?: boolean; // Whether to use the percentage histogram range
+  userTriggered?: boolean; // Whether the user has changed the window/level
 }
 
 export interface LayersConfig {

--- a/src/store/view-configs/windowing.ts
+++ b/src/store/view-configs/windowing.ts
@@ -115,7 +115,11 @@ export const useWindowingStore = defineStore('windowing', () => {
       ...widthLevelPatchOnSwitchingFromAuto,
       ...patch,
       useAuto: effectiveUseAuto,
-      userTriggered: currentInternalConfig?.userTriggered || userTriggered, // one way from false to true
+      // one way from false to true
+      userTriggered:
+        currentInternalConfig?.userTriggered ||
+        userTriggered ||
+        patch.userTriggered,
     };
 
     patchDoubleKeyRecord(configs, viewID, dataID, newInternalConfig);

--- a/src/store/view-configs/windowing.ts
+++ b/src/store/view-configs/windowing.ts
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia';
-import { reactive, ref, watch, WatchStopHandle } from 'vue'; // Added WatchStopHandle
+import { reactive, ref, computed } from 'vue';
 import {
   DoubleKeyRecord,
   deleteSecondKey,
@@ -13,13 +13,14 @@ import { createViewConfigSerializer } from './common';
 import { ViewConfig } from '../../io/state-file/schema';
 import { WindowLevelConfig } from './types';
 
-export const defaultWindowLevelConfig = () => ({
-  width: 1,
-  level: 0.5,
-  auto: WL_AUTO_DEFAULT,
-  useAuto: false,
-  userTriggered: false,
-});
+export const defaultWindowLevelConfig = () =>
+  ({
+    width: 1,
+    level: 0.5,
+    auto: WL_AUTO_DEFAULT,
+    useAuto: false,
+    userTriggered: false,
+  } as const);
 
 type WindowLevel = {
   width: number;
@@ -32,84 +33,61 @@ export const useWindowingStore = defineStore('windowing', () => {
   const runtimeConfigWindowLevel = ref<WindowLevel | undefined>();
   const imageStatsStore = useImageStatsStore();
 
-  // Use DoubleKeyRecord for autoWindowUpdaters
-  const autoWindowUpdaters = reactive<DoubleKeyRecord<WatchStopHandle>>({});
-
   const setSyncAcrossViews = (yn: boolean) => {
     syncAcrossViews.value = yn;
   };
 
-  const getConfig = (viewID: Maybe<string>, dataID: Maybe<string>) =>
+  const getConfig = (viewID: string, dataID: string) => {
+    return computed(() => {
+      const internalConfig = getDoubleKeyRecord(configs, viewID, dataID);
+
+      if (!internalConfig) {
+        return defaultWindowLevelConfig();
+      }
+
+      let widthLevel = {
+        width: internalConfig.width,
+        level: internalConfig.level,
+      };
+      if (internalConfig.useAuto) {
+        const autoKey = internalConfig.auto;
+        const statsRef = imageStatsStore.getAutoRangeValues(dataID);
+        const autoValues = statsRef.value;
+
+        if (autoValues && autoValues[autoKey]) {
+          const [min, max] = autoValues[autoKey];
+          widthLevel = {
+            width: max - min,
+            level: (max + min) / 2,
+          };
+        } else {
+          widthLevel = {
+            width: internalConfig.width,
+            level: internalConfig.level,
+          };
+        }
+      }
+
+      return {
+        ...internalConfig,
+        ...widthLevel,
+      };
+    });
+  };
+
+  const getInternalConfig = (viewID: Maybe<string>, dataID: Maybe<string>) =>
     getDoubleKeyRecord(configs, viewID, dataID);
 
-  /**
-   * Syncs the window/level/min/max params of (srcViewID, srcDataID) across all views sharing the dataset.
-   * @param srcViewID
-   * @param srcDataID
-   */
   const syncWindowLevel = (srcViewID: string, srcDataID: string) => {
     if (!syncAcrossViews.value) return;
-
-    const config = configs[srcViewID]?.[srcDataID];
+    const config = getInternalConfig(srcViewID, srcDataID);
     if (!config) return;
 
     Object.keys(configs)
       .filter((viewID) => viewID !== srcViewID)
       .forEach((viewID) => {
-        patchDoubleKeyRecord(configs, viewID, srcDataID, config);
+        patchDoubleKeyRecord(configs, viewID, srcDataID, { ...config });
       });
-  };
-
-  const teardownAutoWindowUpdater = (viewID: string, dataID: string) => {
-    const stop = getDoubleKeyRecord(autoWindowUpdaters, viewID, dataID);
-    if (stop) {
-      stop();
-      // Remove the specific dataID entry for the viewID
-      if (autoWindowUpdaters[viewID]) {
-        delete autoWindowUpdaters[viewID][dataID];
-        if (Object.keys(autoWindowUpdaters[viewID]).length === 0) {
-          delete autoWindowUpdaters[viewID];
-        }
-      }
-    }
-  };
-
-  const setupAutoWindowUpdater = (viewID: string, dataID: string) => {
-    teardownAutoWindowUpdater(viewID, dataID); // Stop existing watcher if any
-
-    const newStopHandle = watch(
-      [
-        () => imageStatsStore.getAutoRangeValues(dataID).value,
-        () => configs[viewID]?.[dataID],
-      ],
-      ([autoValues, config]) => {
-        if (!config?.useAuto) {
-          return;
-        }
-
-        const autoKey = config.auto || WL_AUTO_DEFAULT;
-        if (autoValues && autoValues[autoKey]) {
-          const [min, max] = autoValues[autoKey];
-          const newWidth = max - min;
-          const newLevel = (max + min) / 2;
-
-          if (config.width !== newWidth || config.level !== newLevel) {
-            patchDoubleKeyRecord(configs, viewID, dataID, {
-              width: newWidth,
-              level: newLevel,
-            });
-            syncWindowLevel(viewID, dataID);
-          }
-        }
-      },
-      { deep: true, immediate: true }
-    );
-
-    // Store the new stop handle
-    if (!autoWindowUpdaters[viewID]) {
-      autoWindowUpdaters[viewID] = {};
-    }
-    autoWindowUpdaters[viewID][dataID] = newStopHandle;
   };
 
   const updateConfig = (
@@ -118,74 +96,42 @@ export const useWindowingStore = defineStore('windowing', () => {
     patch: Partial<WindowLevelConfig>,
     userTriggered = false
   ) => {
-    const currentConfig = configs[viewID]?.[dataID];
+    const currentInternalConfig = getInternalConfig(viewID, dataID);
+    const defaults = defaultWindowLevelConfig();
 
-    // Ensure userTriggered only goes from false to true, never true to false
-    const effectiveUserTriggered =
-      currentConfig?.userTriggered || userTriggered;
+    let effectiveUseAuto = currentInternalConfig?.useAuto ?? defaults.useAuto;
 
-    let effectiveUseAuto =
-      patch.useAuto ??
-      currentConfig?.useAuto ??
-      defaultWindowLevelConfig().useAuto;
-
-    if (patch.auto !== undefined) {
+    if (patch.useAuto !== undefined) {
+      effectiveUseAuto = patch.useAuto;
+    } else if (patch.auto !== undefined) {
       effectiveUseAuto = true;
-    } else if (
-      (patch.width !== undefined || patch.level !== undefined) &&
-      patch.useAuto === undefined
-    ) {
-      effectiveUseAuto = false;
+    } else if (patch.width !== undefined || patch.level !== undefined) {
+      if (patch.useAuto === undefined) {
+        effectiveUseAuto = false;
+      }
     }
 
-    patchDoubleKeyRecord(configs, viewID, dataID, {
-      ...defaultWindowLevelConfig(),
-      ...currentConfig,
+    const newInternalConfig: WindowLevelConfig = {
+      ...defaults,
+      ...(currentInternalConfig ?? {}),
       ...patch,
       useAuto: effectiveUseAuto,
-      userTriggered: effectiveUserTriggered,
-    });
+      userTriggered: currentInternalConfig?.userTriggered || userTriggered,
+    };
 
+    patchDoubleKeyRecord(configs, viewID, dataID, newInternalConfig);
     syncWindowLevel(viewID, dataID);
-    setupAutoWindowUpdater(viewID, dataID);
   };
 
   const removeView = (viewID: string) => {
-    const dataConfigs = configs[viewID];
-    if (dataConfigs) {
-      Object.keys(dataConfigs).forEach((dataID) => {
-        teardownAutoWindowUpdater(viewID, dataID);
-      });
-    }
     delete configs[viewID];
-    if (
-      autoWindowUpdaters[viewID] &&
-      Object.keys(autoWindowUpdaters[viewID]).length === 0
-    ) {
-      delete autoWindowUpdaters[viewID];
-    }
   };
 
   const removeData = (dataID: string, viewID?: string) => {
     if (viewID) {
-      teardownAutoWindowUpdater(viewID, dataID);
       delete configs[viewID]?.[dataID];
     } else {
-      Object.keys(configs).forEach((vID) => {
-        if (configs[vID]?.[dataID]) {
-          teardownAutoWindowUpdater(vID, dataID);
-        }
-      });
       deleteSecondKey(configs, dataID);
-      // Also remove from autoWindowUpdaters for all views
-      Object.keys(autoWindowUpdaters).forEach((vID) => {
-        if (autoWindowUpdaters[vID]?.[dataID]) {
-          delete autoWindowUpdaters[vID][dataID];
-          if (Object.keys(autoWindowUpdaters[vID]).length === 0) {
-            delete autoWindowUpdaters[vID];
-          }
-        }
-      });
     }
   };
 
@@ -194,14 +140,13 @@ export const useWindowingStore = defineStore('windowing', () => {
   const deserialize = (viewID: string, config: Record<string, ViewConfig>) => {
     Object.entries(config).forEach(([dataID, viewConfig]) => {
       if (viewConfig.window) {
-        updateConfig(viewID, dataID, viewConfig.window);
+        updateConfig(viewID, dataID, viewConfig.window as WindowLevelConfig);
       }
     });
   };
 
   return {
     runtimeConfigWindowLevel,
-    configs,
     getConfig,
     setSyncAcrossViews,
     updateConfig,

--- a/src/store/view-configs/windowing.ts
+++ b/src/store/view-configs/windowing.ts
@@ -140,7 +140,7 @@ export const useWindowingStore = defineStore('windowing', () => {
   const deserialize = (viewID: string, config: Record<string, ViewConfig>) => {
     Object.entries(config).forEach(([dataID, viewConfig]) => {
       if (viewConfig.window) {
-        updateConfig(viewID, dataID, viewConfig.window as WindowLevelConfig);
+        updateConfig(viewID, dataID, viewConfig.window);
       }
     });
   };

--- a/src/store/view-configs/windowing.ts
+++ b/src/store/view-configs/windowing.ts
@@ -12,11 +12,9 @@ import { createViewConfigSerializer } from './common';
 import { ViewConfig } from '../../io/state-file/schema';
 import { WindowLevelConfig } from './types';
 
-export const defaultWindowLevelConfig = (): WindowLevelConfig => ({
+export const defaultWindowLevelConfig = () => ({
   width: 1,
   level: 0.5,
-  min: 0,
-  max: 1,
   auto: WL_AUTO_DEFAULT,
   useAuto: false,
   userTriggered: false,
@@ -69,10 +67,25 @@ export const useWindowingStore = defineStore('windowing', () => {
     const effectiveUserTriggered =
       currentConfig?.userTriggered || userTriggered;
 
+    let effectiveUseAuto =
+      patch.useAuto ??
+      currentConfig?.useAuto ??
+      defaultWindowLevelConfig().useAuto;
+
+    if (patch.auto !== undefined) {
+      effectiveUseAuto = true;
+    } else if (
+      (patch.width !== undefined || patch.level !== undefined) &&
+      patch.useAuto === undefined
+    ) {
+      effectiveUseAuto = false;
+    }
+
     patchDoubleKeyRecord(configs, viewID, dataID, {
       ...defaultWindowLevelConfig(),
       ...currentConfig,
       ...patch,
+      useAuto: effectiveUseAuto,
       userTriggered: effectiveUserTriggered,
     });
 

--- a/src/utils/allocateImageFromChunks.ts
+++ b/src/utils/allocateImageFromChunks.ts
@@ -146,6 +146,7 @@ export function allocateImageFromChunks(sortedChunks: Chunk[]) {
   });
   image.getPointData().setScalars(dataArray);
 
+  // Needed for volume rendering to work at start
   // TODO(fli) sane defaults?
   dataArray.setRange({ min: 0, max: 255 }, 0);
 


### PR DESCRIPTION
Keeps the tag or auto histogram window level values from taking over if user already used range manipulator

Adds image-stats store to hold image range and histogram computations

- [x] switching images loses window level if auto histogram value picked
- [x] Radio group tag/ct-presets/auto-range GUI does not update corretly if range manipulator used
- [x] ~~Disable out auto histogram radio options if not fully loaed yet?~~  Or update when histogram is computed?
- [x] ~~fix MouseRangeManipulator step/sensativity computation for windowing~~  actually messing with step is not the correct parameter and finding good scale parameter is not obvious.
- [x] fix deserialization of windowing config from state file 