### PR TITLE
Avoid a flash of white when loading images without W/L info

### DIFF
--- a/src/composables/useWindowingConfig.ts
+++ b/src/composables/useWindowingConfig.ts
@@ -19,9 +19,11 @@ export function useWindowingConfig(
   });
 
   const generateComputed = (prop: 'width' | 'level') => {
+    // show all-black image with W/L of (1, 2^32-1) until slices load in and we get a valid window/level
+    const defaultValue = prop === 'width' ? 1 : 2 ** 32 - 1;
     return computed({
       get: () => {
-        return config.value?.[prop] ?? 0;
+        return config.value?.[prop] ?? defaultValue;
       },
       set: (val) => {
         const imageIdVal = unref(imageID);


### PR DESCRIPTION
Sets the default W/L to be (1, 2^32-1), which will make images appear all black until proper W/L info is computed. 2^32-1 was picked b/c it's sufficiently large to force black.