### PR TITLE
feat(segments): add segment locking with paint protection

### DIFF
--- a/src/components/SegmentList.vue
+++ b/src/components/SegmentList.vue
@@ -157,10 +157,10 @@ function deleteEditingSegment() {
  */
 const toggleLock = (value: number) => {
   const seg = segmentGroupStore.getSegment(groupId.value, value);
-  if (seg?.locked) {
-    segmentGroupStore.unlockSegment(groupId.value, value);
-  } else {
-    segmentGroupStore.lockSegment(groupId.value, value);
+  if (seg) {
+    segmentGroupStore.updateSegment(groupId.value, value, {
+      locked: !seg.locked,
+    });
   }
 }
 </script>

--- a/src/components/SegmentList.vue
+++ b/src/components/SegmentList.vue
@@ -134,6 +134,21 @@ function deleteEditingSegment() {
   if (editingSegmentValue.value) deleteSegment(editingSegmentValue.value);
   stopEditing(false);
 }
+
+/**
+ * Toggles the lock state of a segment.
+ * Locked segments cannot be edited or painted over.
+ * 
+ * @param value - The segment value to toggle lock state for
+ */
+const toggleLock = (value: number) => {
+  const seg = segmentGroupStore.getSegment(groupId.value, value);
+  if (seg?.locked) {
+    segmentGroupStore.unlockSegment(groupId.value, value);
+  } else {
+    segmentGroupStore.lockSegment(groupId.value, value);
+  }
+}
 </script>
 
 <template>
@@ -164,6 +179,18 @@ function deleteEditingSegment() {
       </div>
     </template>
     <template #item-append="{ key, item }">
+      <!-- Lock/unlock segment button -->
+      <v-btn
+        icon
+        size="small"
+        density="compact"
+        class="mr-1"
+        variant="plain"
+        @click.stop="toggleLock(key as number)"
+        :color="item.locked ? 'error' : undefined"
+      >
+        <v-icon>{{ item.locked ? 'mdi-lock' : 'mdi-lock-open' }}</v-icon>
+      </v-btn>
       <v-btn
         icon
         size="small"
@@ -180,14 +207,17 @@ function deleteEditingSegment() {
           item.visible ? 'Hide' : 'Show'
         }}</v-tooltip>
       </v-btn>
+      <!-- Edit segment button (disabled when locked) -->
       <v-btn
         icon="mdi-pencil"
         size="small"
         density="compact"
-        class="ml-auto mr-1"
+        class="mr-1"
         variant="plain"
         @click.stop="startEditing(key as number)"
+        :disabled="item.locked"
       />
+      <!-- Delete segment button (disabled when locked) -->
       <v-btn
         icon="mdi-delete"
         size="small"
@@ -195,6 +225,7 @@ function deleteEditingSegment() {
         class="ml-auto"
         variant="plain"
         @click.stop="deleteSegment(key as number)"
+        :disabled="item.locked"
       />
     </template>
   </editable-chip-list>

--- a/src/components/SegmentList.vue
+++ b/src/components/SegmentList.vue
@@ -71,12 +71,26 @@ const allVisible = computed(() => {
   return segments.value.every((seg) => seg.visible);
 });
 
+const allLocked = computed(() => {
+  return segments.value.every((seg) => seg.locked);
+});
+
 function toggleGlobalVisible() {
   const visible = !allVisible.value;
 
   segments.value.forEach((seg) => {
     segmentGroupStore.updateSegment(groupId.value, seg.value, {
       visible,
+    });
+  });
+}
+
+function toggleGlobalLocked() {
+  const locked = !allLocked.value;
+
+  segments.value.forEach((seg) => {
+    segmentGroupStore.updateSegment(groupId.value, seg.value, {
+      locked,
     });
   });
 }
@@ -159,6 +173,17 @@ const toggleLock = (value: number) => {
       <v-icon v-else class="pl-2">mdi-eye-off</v-icon>
       <v-tooltip location="top" activator="parent">{{
         allVisible ? 'Hide' : 'Show'
+      }}</v-tooltip>
+    </slot>
+  </v-btn>
+
+  <v-btn @click.stop="toggleGlobalLocked" class="my-1">
+    Toggle Locks
+    <slot name="append">
+      <v-icon v-if="allLocked" class="pl-2">mdi-lock</v-icon>
+      <v-icon v-else class="pl-2">mdi-lock-open</v-icon>
+      <v-tooltip location="top" activator="parent">{{
+        allLocked ? 'Unlock All' : 'Lock All'
       }}</v-tooltip>
     </slot>
   </v-btn>

--- a/src/components/SegmentList.vue
+++ b/src/components/SegmentList.vue
@@ -215,6 +215,9 @@ const toggleLock = (value: number) => {
         :color="item.locked ? 'error' : undefined"
       >
         <v-icon>{{ item.locked ? 'mdi-lock' : 'mdi-lock-open' }}</v-icon>
+        <v-tooltip location="left" activator="parent">{{
+          item.locked ? 'Unlock' : 'Lock'
+        }}</v-tooltip>
       </v-btn>
       <v-btn
         icon

--- a/src/components/SegmentList.vue
+++ b/src/components/SegmentList.vue
@@ -180,7 +180,7 @@ const toggleLock = (value: number) => {
   <v-btn @click.stop="toggleGlobalLocked" class="my-1">
     Toggle Locks
     <slot name="append">
-      <v-icon v-if="allLocked" class="pl-2">mdi-lock</v-icon>
+      <v-icon v-if="allLocked" class="pl-2" color="red">mdi-lock</v-icon>
       <v-icon v-else class="pl-2">mdi-lock-open</v-icon>
       <v-tooltip location="top" activator="parent">{{
         allLocked ? 'Unlock All' : 'Lock All'

--- a/src/components/SegmentList.vue
+++ b/src/components/SegmentList.vue
@@ -152,7 +152,7 @@ function deleteEditingSegment() {
 /**
  * Toggles the lock state of a segment.
  * Locked segments cannot be edited or painted over.
- * 
+ *
  * @param value - The segment value to toggle lock state for
  */
 const toggleLock = (value: number) => {
@@ -162,31 +162,33 @@ const toggleLock = (value: number) => {
       locked: !seg.locked,
     });
   }
-}
+};
 </script>
 
 <template>
-  <v-btn @click.stop="toggleGlobalVisible" class="my-1">
-    Toggle Segments
-    <slot name="append">
-      <v-icon v-if="allVisible" class="pl-2">mdi-eye</v-icon>
-      <v-icon v-else class="pl-2">mdi-eye-off</v-icon>
-      <v-tooltip location="top" activator="parent">{{
-        allVisible ? 'Hide' : 'Show'
-      }}</v-tooltip>
-    </slot>
-  </v-btn>
+  <div class="d-flex justify-space-evenly">
+    <v-btn @click.stop="toggleGlobalVisible" class="my-1">
+      Toggle Segments
+      <slot name="append">
+        <v-icon v-if="allVisible" class="pl-2">mdi-eye</v-icon>
+        <v-icon v-else class="pl-2">mdi-eye-off</v-icon>
+        <v-tooltip location="top" activator="parent">{{
+          allVisible ? 'Hide' : 'Show'
+        }}</v-tooltip>
+      </slot>
+    </v-btn>
 
-  <v-btn @click.stop="toggleGlobalLocked" class="my-1">
-    Toggle Locks
-    <slot name="append">
-      <v-icon v-if="allLocked" class="pl-2" color="red">mdi-lock</v-icon>
-      <v-icon v-else class="pl-2">mdi-lock-open</v-icon>
-      <v-tooltip location="top" activator="parent">{{
-        allLocked ? 'Unlock All' : 'Lock All'
-      }}</v-tooltip>
-    </slot>
-  </v-btn>
+    <v-btn @click.stop="toggleGlobalLocked" class="my-1">
+      Toggle Locks
+      <slot name="append">
+        <v-icon v-if="allLocked" class="pl-2" color="red">mdi-lock</v-icon>
+        <v-icon v-else class="pl-2">mdi-lock-open</v-icon>
+        <v-tooltip location="top" activator="parent">{{
+          allLocked ? 'Unlock All' : 'Lock All'
+        }}</v-tooltip>
+      </slot>
+    </v-btn>
+  </div>
 
   <editable-chip-list
     v-model="selectedSegment"

--- a/src/store/segmentGroups.ts
+++ b/src/store/segmentGroups.ts
@@ -432,7 +432,6 @@ export const useSegmentGroupStore = defineStore('segmentGroup', () => {
     };
   }
 
-
   /**
    * Deletes a segment from a labelmap.
    * @param segmentGroupID

--- a/src/store/segmentGroups.ts
+++ b/src/store/segmentGroups.ts
@@ -390,6 +390,7 @@ export const useSegmentGroupStore = defineStore('segmentGroup', () => {
       value,
       color: [...getNextColor()],
       visible: true,
+      locked: false, // default to unlocked
     };
   }
 
@@ -429,6 +430,24 @@ export const useSegmentGroupStore = defineStore('segmentGroup', () => {
       ...segment,
       ...segmentUpdate,
     };
+  }
+
+  /**
+   * Locks a segment, preventing it from being modified during paint operations.
+   * @param segmentGroupID
+   * @param segmentValue
+   */
+  function lockSegment(segmentGroupID: string, segmentValue: number) {
+    updateSegment(segmentGroupID, segmentValue, { locked: true });
+  }
+  
+  /**
+   * Unlocks a segment, allowing it to be modified during paint operations.
+   * @param segmentGroupID
+   * @param segmentValue
+   */
+  function unlockSegment(segmentGroupID: string, segmentValue: number) {
+    updateSegment(segmentGroupID, segmentValue, { locked: false });
   }
 
   /**
@@ -587,6 +606,8 @@ export const useSegmentGroupStore = defineStore('segmentGroup', () => {
     getSegment,
     updateSegment,
     deleteSegment,
+    lockSegment,
+    unlockSegment,
     serialize,
     deserialize,
   };

--- a/src/store/segmentGroups.ts
+++ b/src/store/segmentGroups.ts
@@ -432,23 +432,6 @@ export const useSegmentGroupStore = defineStore('segmentGroup', () => {
     };
   }
 
-  /**
-   * Locks a segment, preventing it from being modified during paint operations.
-   * @param segmentGroupID
-   * @param segmentValue
-   */
-  function lockSegment(segmentGroupID: string, segmentValue: number) {
-    updateSegment(segmentGroupID, segmentValue, { locked: true });
-  }
-  
-  /**
-   * Unlocks a segment, allowing it to be modified during paint operations.
-   * @param segmentGroupID
-   * @param segmentValue
-   */
-  function unlockSegment(segmentGroupID: string, segmentValue: number) {
-    updateSegment(segmentGroupID, segmentValue, { locked: false });
-  }
 
   /**
    * Deletes a segment from a labelmap.
@@ -606,8 +589,6 @@ export const useSegmentGroupStore = defineStore('segmentGroup', () => {
     getSegment,
     updateSegment,
     deleteSegment,
-    lockSegment,
-    unlockSegment,
     serialize,
     deserialize,
   };

--- a/src/store/tools/paint.ts
+++ b/src/store/tools/paint.ts
@@ -134,6 +134,14 @@ export const usePaintToolStore = defineStore('paint', () => {
       return;
     }
 
+    // Prevent painting if active segment is locked
+    if (activeSegmentGroupID.value && activeSegment.value) {
+      const segment = segmentGroupStore.getSegment(activeSegmentGroupID.value, activeSegment.value);
+      if (segment?.locked) {
+        return;
+      }
+    }
+
     const underlyingImagePixels = currentImageData.value
       ?.getPointData()
       .getScalars()

--- a/src/store/tools/paint.ts
+++ b/src/store/tools/paint.ts
@@ -141,8 +141,6 @@ export const usePaintToolStore = defineStore('paint', () => {
     const [minThreshold, maxThreshold] = thresholdRange.value;
     const shouldPaint = (idx: number) => {
       if (!underlyingImagePixels) return false;
-      const pixValue = underlyingImagePixels[idx];
-      const inThreshold = minThreshold <= pixValue && pixValue <= maxThreshold;
       
       // Prevent painting over locked segments
       if (activeSegmentGroupID.value && activeLabelmap.value) {
@@ -157,7 +155,8 @@ export const usePaintToolStore = defineStore('paint', () => {
         }
       }
       
-      return inThreshold;
+      const pixValue = underlyingImagePixels[idx];
+      return minThreshold <= pixValue && pixValue <= maxThreshold;
     };
 
     const lastIndex = strokePoints.value.length - 1;

--- a/src/store/tools/paint.ts
+++ b/src/store/tools/paint.ts
@@ -136,7 +136,10 @@ export const usePaintToolStore = defineStore('paint', () => {
 
     // Prevent painting if active segment is locked
     if (activeSegmentGroupID.value && activeSegment.value) {
-      const segment = segmentGroupStore.getSegment(activeSegmentGroupID.value, activeSegment.value);
+      const segment = segmentGroupStore.getSegment(
+        activeSegmentGroupID.value,
+        activeSegment.value
+      );
       if (segment?.locked) {
         return;
       }
@@ -149,12 +152,16 @@ export const usePaintToolStore = defineStore('paint', () => {
     const [minThreshold, maxThreshold] = thresholdRange.value;
     const shouldPaint = (idx: number) => {
       if (!underlyingImagePixels) return false;
-      
+
       // Prevent painting over locked segments
       if (activeSegmentGroupID.value && activeLabelmap.value) {
-        const metadata = segmentGroupStore.metadataByID[activeSegmentGroupID.value];
+        const metadata =
+          segmentGroupStore.metadataByID[activeSegmentGroupID.value];
         if (metadata) {
-          const currentData = activeLabelmap.value.getPointData().getScalars().getData() as Uint8Array;
+          const currentData = activeLabelmap.value
+            .getPointData()
+            .getScalars()
+            .getData() as Uint8Array;
           const currentValue = currentData[idx];
           const segment = metadata.segments.byValue[currentValue];
           if (segment?.locked) {
@@ -162,7 +169,7 @@ export const usePaintToolStore = defineStore('paint', () => {
           }
         }
       }
-      
+
       const pixValue = underlyingImagePixels[idx];
       return minThreshold <= pixValue && pixValue <= maxThreshold;
     };

--- a/src/store/tools/paintProcess.ts
+++ b/src/store/tools/paintProcess.ts
@@ -96,7 +96,10 @@ export const usePaintProcessStore = defineStore('paintProcess', () => {
     }
 
     // Check if the active segment is locked
-    const segment = segmentGroupStore.getSegment(groupId, paintStore.activeSegment);
+    const segment = segmentGroupStore.getSegment(
+      groupId,
+      paintStore.activeSegment
+    );
     if (segment?.locked) {
       messageStore.addError('Cannot process locked segment');
       return;

--- a/src/store/tools/paintProcess.ts
+++ b/src/store/tools/paintProcess.ts
@@ -95,6 +95,13 @@ export const usePaintProcessStore = defineStore('paintProcess', () => {
       return;
     }
 
+    // Check if the active segment is locked
+    const segment = segmentGroupStore.getSegment(groupId, paintStore.activeSegment);
+    if (segment?.locked) {
+      messageStore.addError('Cannot process locked segment');
+      return;
+    }
+
     const segImage = segmentGroupStore.dataIndex[groupId];
 
     const originalScalars = segImage

--- a/src/types/segment.ts
+++ b/src/types/segment.ts
@@ -5,4 +5,5 @@ export interface SegmentMask {
   name: string;
   color: RGBAColor;
   visible: boolean;
+  locked?: boolean;
 }


### PR DESCRIPTION
Adds lock/unlock buttons to individual segments to prevent them from accidental modification when painting other segments.

![image](https://github.com/user-attachments/assets/cfdf2d11-0a83-488b-9b79-9ea4abc41d49)