### PR TITLE
feat(PaintWidget2D): Add modifier+scroll shortcut for brush size

### DIFF
--- a/src/components/ControlsModal.vue
+++ b/src/components/ControlsModal.vue
@@ -16,10 +16,6 @@
             <td>Pan</td>
             <td>Shift + left mouse button + move</td>
           </tr>
-          <tr>
-            <td>Adjust Brush Size</td>
-            <td>Ctrl + mouse wheel or two finger vertical scroll</td>
-          </tr>
         </tbody>
       </v-table>
 

--- a/src/components/ControlsModal.vue
+++ b/src/components/ControlsModal.vue
@@ -16,6 +16,10 @@
             <td>Pan</td>
             <td>Shift + left mouse button + move</td>
           </tr>
+          <tr>
+            <td>Adjust Brush Size</td>
+            <td>Ctrl + mouse wheel or two finger vertical scroll</td>
+          </tr>
         </tbody>
       </v-table>
 

--- a/src/components/tools/paint/PaintWidget2D.vue
+++ b/src/components/tools/paint/PaintWidget2D.vue
@@ -162,15 +162,19 @@ export default defineComponent({
       const delta = event.deltaY < 0 ? 1 : -1;
       const newSize = Math.max(1, Math.min(50, paintStore.brushSize + delta));
       paintStore.setBrushSize(newSize);
-    }
+    };
 
     onMounted(() => {
-      view.renderWindowView.getContainer()?.addEventListener('wheel', handleWheelEvent, { passive: false });
+      view.renderWindowView
+        .getContainer()
+        ?.addEventListener('wheel', handleWheelEvent, { passive: false });
     });
 
     onUnmounted(() => {
-      view.renderWindowView.getContainer()?.removeEventListener('wheel', handleWheelEvent);
-    })
+      view.renderWindowView
+        .getContainer()
+        ?.removeEventListener('wheel', handleWheelEvent);
+    });
 
     return () => null;
   },

--- a/src/components/tools/paint/PaintWidget2D.vue
+++ b/src/components/tools/paint/PaintWidget2D.vue
@@ -9,6 +9,7 @@ import {
   watchEffect,
   inject,
 } from 'vue';
+import { useMagicKeys } from '@vueuse/core';
 import vtkPlaneManipulator from '@kitware/vtk.js/Widgets/Manipulators/PlaneManipulator';
 import { getLPSAxisFromDir } from '@/src/utils/lps';
 import { useImage } from '@/src/composables/useCurrentImage';
@@ -22,6 +23,7 @@ import { useSliceInfo } from '@/src/composables/useSliceInfo';
 import { VtkViewContext } from '@/src/components/vtk/context';
 import { Maybe } from '@/src/types';
 import { PaintMode } from '@/src/core/tools/paint';
+import { actionToKey } from '@/src/composables/useKeyboardShortcuts';
 
 export default defineComponent({
   name: 'PaintWidget2D',
@@ -155,9 +157,14 @@ export default defineComponent({
       widget.setEnabled(paintStore.activeMode !== PaintMode.Process);
     });
 
-    // Brush size scroll wheel control
+    // Brush size scroll wheel control with customizable modifier key
+    const keys = useMagicKeys();
+    const enableBrushSizeAdjustment = computed(
+      () => keys[actionToKey.value.brushSize].value
+    );
+
     const handleWheelEvent = (event: WheelEvent) => {
-      if (!event.ctrlKey) return;
+      if (!enableBrushSizeAdjustment.value) return;
       event.preventDefault();
       const delta = event.deltaY < 0 ? 1 : -1;
       const newSize = Math.max(1, Math.min(50, paintStore.brushSize + delta));

--- a/src/components/tools/paint/PaintWidget2D.vue
+++ b/src/components/tools/paint/PaintWidget2D.vue
@@ -155,6 +155,23 @@ export default defineComponent({
       widget.setEnabled(paintStore.activeMode !== PaintMode.Process);
     });
 
+    // Brush size scroll wheel control
+    const handleWheelEvent = (event: WheelEvent) => {
+      if (!event.ctrlKey) return;
+      event.preventDefault();
+      const delta = event.deltaY < 0 ? 1 : -1;
+      const newSize = Math.max(1, Math.min(50, paintStore.brushSize + delta));
+      paintStore.setBrushSize(newSize);
+    }
+
+    onMounted(() => {
+      view.renderWindowView.getContainer()?.addEventListener('wheel', handleWheelEvent, { passive: false });
+    });
+
+    onUnmounted(() => {
+      view.renderWindowView.getContainer()?.removeEventListener('wheel', handleWheelEvent);
+    })
+
     return () => null;
   },
 });

--- a/src/composables/actions.ts
+++ b/src/composables/actions.ts
@@ -67,6 +67,7 @@ export const ACTION_TO_FUNC = {
   zoom: setTool(Tools.Zoom),
   ruler: setTool(Tools.Ruler),
   paint: setTool(Tools.Paint),
+  brushSize: NOOP, // act as modifier key rather than immediate effect, so no-op
   rectangle: setTool(Tools.Rectangle),
   crosshairs: setTool(Tools.Crosshairs),
   temporaryCrosshairs: NOOP, // behavior implemented elsewhere

--- a/src/config.ts
+++ b/src/config.ts
@@ -269,6 +269,7 @@ export const ACTION_TO_KEY = {
   zoom: 'z',
   ruler: 'm',
   paint: 'p',
+  brushSize: 'ctrl',
   rectangle: 'r',
   crosshairs: 'c',
   temporaryCrosshairs: 'shift-c',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -38,6 +38,9 @@ export const ACTIONS = {
   paint: {
     readable: 'Activate Paint tool',
   },
+  brushSize: {
+    readable: 'Change brush size by holding key and scrolling',
+  },
   rectangle: {
     readable: 'Activate Rectangle tool',
   },


### PR DESCRIPTION
Adds Ctrl+scroll (mouse wheel or two finger scroll) functionality to adjust paint brush size.

Related to #716!