### PR TITLE
fix(config): Add sample data visibility env flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,3 +14,6 @@ VITE_ENABLE_REMOTE_SAVE=true
 
 # VolView server remote URL
 VITE_REMOTE_SERVER_URL=http://localhost:4014
+
+# Controls the initial visibility of the Sample Data section.
+VITE_SHOW_SAMPLE_DATA=true

--- a/src/store/data-browser.ts
+++ b/src/store/data-browser.ts
@@ -2,7 +2,8 @@ import { defineStore } from 'pinia';
 import { ref } from 'vue';
 
 export const useDataBrowserStore = defineStore('data-browser', () => {
-  const hideSampleData = ref(false);
+  const hideSampleData = ref(import.meta.env.VITE_SHOW_SAMPLE_DATA !== 'true');
+
   return {
     hideSampleData,
   };


### PR DESCRIPTION
Closes #759

Configures the initial visibility state at build time. Can prevent a benign race condition between the default (true) and runtime-fetched (false) settings where delayed state update looks ugly.