### PR TITLE
feat(test): upload screenshots of full browser window on any E2E test failure

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -42,5 +42,5 @@ jobs:
         continue-on-error: true
         with:
           name: image_comparison_results_${{ matrix.os }}
-          path: .tmp
+          path: ${{ github.workspace }}/.tmp/
           retention-days: 5

--- a/wdio.shared.conf.ts
+++ b/wdio.shared.conf.ts
@@ -101,6 +101,30 @@ export const config: Options.Testrunner = {
     });
   },
 
+  async afterTest(
+    test: any,
+    _context: any,
+    result: { passed: boolean }
+  ) {
+    if (!result.passed) {
+      // Save a screenshot of the browser window if the test failed.
+      const slug = String(test.fullTitle || test.title || 'unknown')
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '');
+      const filename = `${slug}-${Date.now()}.png`;
+      const failureScreenshotDir = path.join(TEMP_DIR, 'failure-screenshots');
+      fs.mkdirSync(failureScreenshotDir, { recursive: true });
+      const filepath = path.resolve(failureScreenshotDir, filename);
+      try {
+        await browser.saveScreenshot(filepath);
+        console.log(`Saved failure screenshot: ${filepath}`);
+      } catch (e) {
+        console.warn('Failed to save failure screenshot', e);
+      }
+    }
+  },
+
   async afterCommand(commandName: string) {
     // After navigation, inject console interceptor to stringify errors
     if (commandName === 'navigateTo' || commandName === 'url') {


### PR DESCRIPTION
Don't merge this yet, I'm just trying to test to make sure this works in GH Actions.