### PR TITLE
fix(test): reduce concurrency in E2E testing in CI

### DIFF
--- a/wdio.shared.conf.ts
+++ b/wdio.shared.conf.ts
@@ -32,7 +32,8 @@ export const config: Options.Testrunner = {
   // ============
   // Capabilities
   // ============
-  maxInstances: 3,
+  // Limit the number of browser instances to 1 in CI to avoid memory limits
+  maxInstances: process.env.CI ? 1 : 3,
   //
   // ===================
   // Test Configurations


### PR DESCRIPTION
It seems the flakiness was a result of the browser processes getting OOM-killed, and the harness not doing a great job of detecting or at least alerting about that fact.