### PR TITLE
fix: reverse arrow key and alt mouse slice direction

### DIFF
--- a/src/components/vtk/VtkSliceViewSlicingKeyManipulator.vue
+++ b/src/components/vtk/VtkSliceViewSlicingKeyManipulator.vue
@@ -66,7 +66,8 @@ const scroll = useMouseRangeManipulatorListener(
   'vertical',
   sliceConfig.range,
   1,
-  sliceConfig.slice.value
+  sliceConfig.slice.value,
+  -1
 );
 
 syncRef(scroll, sliceConfig.slice, { immediate: true });

--- a/src/composables/actions.ts
+++ b/src/composables/actions.ts
@@ -91,8 +91,8 @@ export const ACTION_TO_FUNC = {
   polygon: setTool(Tools.Polygon),
   select: setTool(Tools.Select),
 
-  nextSlice: changeSlice(1),
-  previousSlice: changeSlice(-1),
+  nextSlice: changeSlice(-1),
+  previousSlice: changeSlice(1),
   grabSlice: NOOP, // acts as a modifier key rather than immediate effect, so no-op
 
   decrementLabel: applyLabelOffset(-1),


### PR DESCRIPTION
For anatomical consistency.  Related to #811 