### PR TITLE
chore(ci): add NPM auto-publish workflow

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -29,7 +29,7 @@ jobs:
             echo "latest=$LATEST_TAG" >> $GITHUB_OUTPUT
           fi
 
-      - name: Bump patch version
+      - name: Bump prerelease version
         id: bump_version
         run: |
           LATEST_VERSION="${{ steps.get_version.outputs.latest }}"
@@ -37,7 +37,7 @@ jobs:
 
           echo "$VERSION_NUMBER" > VERSION_TEMP
           npm version --no-git-tag-version $VERSION_NUMBER
-          npm version --no-git-tag-version patch
+          npm version --no-git-tag-version prerelease --preid=dev
 
           NEW_VERSION=$(node -p "require('./package.json').version")
           echo "new_version=v$NEW_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -3,6 +3,7 @@ name: Publish to NPM
 on:
   push:
     tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
@@ -24,6 +25,11 @@ jobs:
         run: |
           VERSION="${GITHUB_REF#refs/tags/v}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          if [[ "$VERSION" == *"-dev."* ]]; then
+            echo "tag=dev" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
 
       - name: Update package.json version
         run: npm version --no-git-tag-version ${{ steps.get_version.outputs.version }}
@@ -34,4 +40,4 @@ jobs:
       - name: Build with remote save enabled
         run: VITE_REMOTE_SERVER_URL= VITE_ENABLE_REMOTE_SAVE=true npm run build
 
-      - run: npm publish --provenance --access public
+      - run: npm publish --provenance --access public --tag ${{ steps.get_version.outputs.tag }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,19 +96,28 @@ npm run test:e2e:dev -- -- --spec ./tests/specs/remote-manifest.e2e.ts
 
 ---
 
-## NPM Publishing
+## Versioning
 
-Merging to `main` automatically publishes to NPM:
+Merging to `main` automatically publishes dev versions to NPM:
 
-1. Merge creates a patch version tag (v4.4.1, v4.4.2, etc.)
-2. Tag triggers automatic NPM publish
+1. Merge creates a prerelease tag (v4.4.0-dev.1, v4.4.0-dev.2, etc.)
+2. Tag triggers automatic NPM publish with `@dev` dist-tag
 
-For minor/major releases, manually create a tag:
+Users install stable versions by default:
+
+```bash
+npm install volview          # Gets latest stable (e.g., 4.4.0)
+npm install volview@dev      # Gets latest dev (e.g., 4.4.0-dev.5)
+```
+
+For stable releases, manually create a tag:
 
 ```bash
 git tag v4.5.0  # or v5.0.0
 git push origin v4.5.0
 ```
+
+### Update demo site
 
 To update https://volview.kitware.app/, merge to the `stable` branch.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "volview",
   "version": "4.4.0",
   "type": "module",
-  "files": ["dist", "src"],
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
     "dev": "cross-env VITE_SHOW_SAMPLE_DATA=true vite",
     "preview": "vite preview",


### PR DESCRIPTION
## NPM Auto-Publishing

Tag-based approach that avoids committing version bumps to main.

### Flow

1. Merge to main → `bump-version.yml` creates version tag (v4.4.1, v4.4.2, etc.)
2. New tag → `publish-npm.yml` publishes to NPM

For minor/major releases, manually create tags:
```bash
git tag v4.5.0
git push origin v4.5.0
```

Setup done for OIDC trusted publishing on npmjs.com

closes #814 