### PR TITLE
Fix updateSegment function proxy the segments js object

### DIFF
--- a/src/store/segmentGroups.ts
+++ b/src/store/segmentGroups.ts
@@ -430,7 +430,7 @@ export const useSegmentGroupStore = defineStore('segmentGroup', () => {
     const metadata = getMetadata(segmentGroupID);
     const segment = getSegment(segmentGroupID, segmentValue);
     metadata.segments.byValue[segmentValue] = {
-      ...segment,
+      ...toRaw(segment),
       ...segmentUpdate,
     };
   }


### PR DESCRIPTION
The `segmentGroupStore.updateSegment` function some how makes the `metadata.segments.byValue.color` field a proxy array.

Steps to reproduce: click the [Lock] or [Hide] toggle button, which calls the `updateSegment` function:
<img width="634" height="200" alt="image" src="https://github.com/user-attachments/assets/fc5de26c-55e7-46f9-9517-fa7cd1cf6766" />

then, this object becomes proxied:

<img width="740" height="373" alt="image" src="https://github.com/user-attachments/assets/622f48e5-5a31-4df1-a73e-d7aff12de1a4" />

This leads to errors in below scenarios:

1. Failed to create new segment group, which calls the `structuredClone`
<img width="317" height="58" alt="image" src="https://github.com/user-attachments/assets/63d0ae01-a27a-4b9d-96af-ee92870b4fbb" />
<img width="1469" height="229" alt="image" src="https://github.com/user-attachments/assets/dd6f090f-93cc-4d51-a3b6-d4678842a906" />

2. Failed to save session, which calls the `postMessage`
<img width="760" height="338" alt="image" src="https://github.com/user-attachments/assets/f4ab1af2-289c-4534-995f-7cf09bf08525" />
<img width="1247" height="240" alt="image" src="https://github.com/user-attachments/assets/031b5d5c-c0ba-4709-8003-e36cb652a65f" />