### PR TITLE
Add copyable bug report on errors

### DIFF
--- a/src/components/MessageItem.vue
+++ b/src/components/MessageItem.vue
@@ -30,7 +30,7 @@ export default defineComponent({
     });
 
     const copyBugReport = () => {
-      const report = message.value.options.bugReport;
+      const report = message.value.bugReport;
       if (report) copy(report);
     };
 
@@ -50,7 +50,7 @@ export default defineComponent({
         <span>{{ message.title }}</span>
         <div>
           <v-btn
-            v-if="message.options.bugReport"
+            v-if="message.bugReport"
             :prepend-icon="copied ? 'mdi-check' : 'mdi-content-copy'"
             variant="tonal"
             size="small"

--- a/src/components/MessageItem.vue
+++ b/src/components/MessageItem.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { computed, defineComponent, PropType, toRefs } from 'vue';
+import { useClipboard } from '@vueuse/core';
 import { Message, MessageType } from '../store/messages';
 
 const MessageTypeClass: Record<MessageType, string> = {
@@ -18,6 +19,7 @@ export default defineComponent({
   },
   setup(props) {
     const { message } = toRefs(props);
+    const { copy, copied } = useClipboard();
 
     const headerClass = computed(() => {
       const type = MessageTypeClass[message.value.type];
@@ -27,8 +29,15 @@ export default defineComponent({
       return '';
     });
 
+    const copyBugReport = () => {
+      const report = message.value.options.bugReport;
+      if (report) copy(report);
+    };
+
     return {
       headerClass,
+      copied,
+      copyBugReport,
     };
   },
 });
@@ -39,13 +48,25 @@ export default defineComponent({
     <v-expansion-panel-title :class="headerClass">
       <div class="header">
         <span>{{ message.title }}</span>
-        <v-btn
-          icon="mdi-delete"
-          variant="text"
-          size="small"
-          class="mr-3"
-          @click.stop="$emit('delete')"
-        />
+        <div>
+          <v-btn
+            v-if="message.options.bugReport"
+            :prepend-icon="copied ? 'mdi-check' : 'mdi-content-copy'"
+            variant="tonal"
+            size="small"
+            data-testid="copy-bug-report-button"
+            @click.stop="copyBugReport"
+          >
+            Copy Bug Report
+          </v-btn>
+          <v-btn
+            icon="mdi-delete"
+            variant="text"
+            size="small"
+            class="mr-3"
+            @click.stop="$emit('delete')"
+          />
+        </div>
       </div>
     </v-expansion-panel-title>
     <v-expansion-panel-text v-if="message.options.details">

--- a/src/components/PatientStudyVolumeBrowser.vue
+++ b/src/components/PatientStudyVolumeBrowser.vue
@@ -118,6 +118,7 @@ export default defineComponent({
             if (err instanceof Error) {
               const messageStore = useMessageStore();
               messageStore.addError('Failed to generate thumbnails', {
+                error: err,
                 details: `${err}. More details can be found in the developer's console.`,
               });
             }

--- a/src/components/SampleDataBrowser.vue
+++ b/src/components/SampleDataBrowser.vue
@@ -115,7 +115,9 @@ export default defineComponent({
       } catch (error) {
         status.progress[sample.name].state = ProgressState.Error;
         const messageStore = useMessageStore();
-        messageStore.addError('Failed to load sample data', error as Error);
+        messageStore.addError('Failed to load sample data', {
+          error: error as Error,
+        });
       } finally {
         delete status.progress[sample.name];
       }

--- a/src/composables/useErrorMessage.ts
+++ b/src/composables/useErrorMessage.ts
@@ -7,6 +7,7 @@ export async function useErrorMessage(message: string, task: Function) {
     if (err instanceof Error) {
       const messageStore = useMessageStore();
       messageStore.addError(message, {
+        error: err,
         details: `${err}. More details can be found in the developer's console.`,
       });
     }

--- a/src/composables/useGlobalErrorHook.ts
+++ b/src/composables/useGlobalErrorHook.ts
@@ -7,12 +7,16 @@ export function useGlobalErrorHook() {
 
   const onError = (event: ErrorEvent) => {
     console.error(event);
-    const errorMessage = event.message ?? 'Unknown global error';
+    const error = event.error ?? event.message ?? 'Unknown global error';
 
-    captureException(event.error ?? errorMessage);
+    captureException(error);
 
-    const details = event.error ? event.error : { details: errorMessage };
-    messageStore.addError('Application error (click for details)', details);
+    const errorOptions =
+      error instanceof Error ? { error } : { details: String(error) };
+    messageStore.addError(
+      'Application error (click for details)',
+      errorOptions
+    );
   };
 
   onMounted(() => {

--- a/src/composables/useWebGLWatchdog.ts
+++ b/src/composables/useWebGLWatchdog.ts
@@ -33,7 +33,9 @@ function getVolumeMapperContext(view: View) {
 export function useWebGLWatchdog(view: MaybeRef<Maybe<View>>) {
   const reportError = useThrottleFn(() => {
     const messageStore = useMessageStore();
-    messageStore.addError(Messages.WebGLLost.title, Messages.WebGLLost.details);
+    messageStore.addError(Messages.WebGLLost.title, {
+      details: Messages.WebGLLost.details,
+    });
 
     const contexts: Record<string, any> = {};
     const viewVal = unref(view);

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -12,3 +12,4 @@ interface ImportMeta {
 }
 
 declare const __VERSIONS__: Record<string, string>;
+declare const __GIT_SHORT_SHA__: string;

--- a/src/io/import/processors/restoreStateFile.ts
+++ b/src/io/import/processors/restoreStateFile.ts
@@ -52,10 +52,9 @@ function resolveToLeafSources(
         return [{ type: 'file', file, fileType: src.fileType }];
       }
       const missingFile = filePath ?? String(src.fileId);
-      useMessageStore().addError(
-        'State file missing expected file',
-        missingFile
-      );
+      useMessageStore().addError('State file missing expected file', {
+        details: missingFile,
+      });
       return [];
     }
 

--- a/src/store/__tests__/messages.spec.ts
+++ b/src/store/__tests__/messages.spec.ts
@@ -12,7 +12,7 @@ describe('Message store', () => {
 
     const innerError = new Error('inner error');
     const ids = [
-      messageStore.addError('an error', innerError),
+      messageStore.addError('an error', { error: innerError }),
       messageStore.addWarning('warning'),
       messageStore.addInfo('info'),
       messageStore.addInfo('loading', {
@@ -26,7 +26,7 @@ describe('Message store', () => {
         type: MessageType.Error,
         title: 'an error',
         options: {
-          details: String(innerError),
+          details: innerError.stack ?? String(innerError),
           persist: false,
         },
       },
@@ -57,7 +57,7 @@ describe('Message store', () => {
     expect(messageStore.messages).to.have.length(4);
 
     ids.forEach((id, index) => {
-      expect(messageStore.byID[id]).to.deep.equal(expected[index]);
+      expect(messageStore.byID[id]).toMatchObject(expected[index]);
     });
 
     messageStore.clearOne(ids[1]);

--- a/src/store/dicom-web/dicom-web-store.ts
+++ b/src/store/dicom-web/dicom-web-store.ts
@@ -202,7 +202,7 @@ export const useDicomWebStore = defineStore('dicom-web', () => {
       };
     } catch (error) {
       const messageStore = useMessageStore();
-      messageStore.addError('Failed to load DICOM', error as Error);
+      messageStore.addError('Failed to load DICOM', { error: error as Error });
       volumes.value[volumeKey] = {
         ...volumes.value[volumeKey],
         state: 'Error',

--- a/src/store/image-cache.ts
+++ b/src/store/image-cache.ts
@@ -53,7 +53,7 @@ export const useImageCacheStore = defineStore('image-cache', () => {
       imageErrors[id].push(error);
 
       const messageStore = useMessageStore();
-      messageStore.addError('Error loading DICOM data', error);
+      messageStore.addError('Error loading DICOM data', { error });
     };
 
     imageListenerCleanup[id] = () => {

--- a/src/store/image-stats.ts
+++ b/src/store/image-stats.ts
@@ -178,7 +178,7 @@ export const useImageStatsStore = defineStore('image-stats', () => {
           );
           messageStore.addError(
             `Auto range computation failed for image ${id}`,
-            ensureError(error)
+            { error: ensureError(error) }
           );
         })
         .finally(() => {

--- a/src/store/load-data.ts
+++ b/src/store/load-data.ts
@@ -61,7 +61,7 @@ export function useLoadingNotifications() {
     if (error) {
       logError(error);
       toast.dismiss(toastID);
-      messageStore.addError(NotificationMessages.Error, error);
+      messageStore.addError(NotificationMessages.Error, { error });
     } else {
       toast.update(toastID, {
         content: NotificationMessages.Done,

--- a/src/store/messages.ts
+++ b/src/store/messages.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia';
 import { removeFromArray } from '../utils';
+import { generateBugReport } from '../utils/bugReport';
 
 export enum MessageType {
   Error,
@@ -10,6 +11,7 @@ export enum MessageType {
 
 export type MessageOptions = {
   details?: string;
+  bugReport?: string;
   persist?: boolean;
 };
 
@@ -22,6 +24,7 @@ export interface Message {
 
 export type UpdateProgressFunction = (progress: number) => void;
 export type TaskFunction = (updateProgress?: UpdateProgressFunction) => any;
+
 interface State {
   _nextID: number;
   byID: Record<string, Message>;
@@ -52,25 +55,31 @@ export const useMessageStore = defineStore('message', {
     addError(title: string, opts?: Error | string | MessageOptions) {
       console.error(title, opts);
 
+      let id: string;
       if (opts instanceof Error) {
-        return this._addMessage(
+        id = this._addMessage(
           {
             type: MessageType.Error,
             title,
           },
           {
-            details: String(opts),
+            details: opts.stack ?? String(opts),
             persist: false,
           }
         );
+      } else {
+        id = this._addMessage(
+          {
+            type: MessageType.Error,
+            title,
+          },
+          opts
+        );
       }
-      return this._addMessage(
-        {
-          type: MessageType.Error,
-          title,
-        },
-        opts
-      );
+
+      this.byID[id].options.bugReport = generateBugReport(opts);
+
+      return id;
     },
     /**
      * Adds a warning message.

--- a/src/store/messages.ts
+++ b/src/store/messages.ts
@@ -56,18 +56,17 @@ export const useMessageStore = defineStore('message', {
     addError(title: string, opts?: ErrorOptions) {
       console.error(title, opts?.error ?? opts?.details);
 
-      const details =
-        opts?.details ??
-        (opts?.error ? (opts.error.stack ?? String(opts.error)) : undefined);
-
-      const id = this._addMessage(
-        { type: MessageType.Error, title },
-        { details, persist: opts?.persist ?? false }
+      return this._addMessage(
+        {
+          type: MessageType.Error,
+          title,
+          bugReport: generateBugReport(opts?.error),
+        },
+        {
+          details: opts?.details ?? opts?.error?.stack,
+          persist: opts?.persist ?? false,
+        }
       );
-
-      this.byID[id].bugReport = generateBugReport(opts?.error);
-
-      return id;
     },
     /**
      * Adds a warning message.

--- a/src/store/messages.ts
+++ b/src/store/messages.ts
@@ -11,7 +11,6 @@ export enum MessageType {
 
 export type MessageOptions = {
   details?: string;
-  bugReport?: string;
   persist?: boolean;
 };
 
@@ -20,7 +19,14 @@ export interface Message {
   type: MessageType;
   title: string;
   options: MessageOptions;
+  bugReport?: string;
 }
+
+export type ErrorOptions = {
+  error?: Error;
+  details?: string;
+  persist?: boolean;
+};
 
 export type UpdateProgressFunction = (progress: number) => void;
 export type TaskFunction = (updateProgress?: UpdateProgressFunction) => any;
@@ -47,37 +53,19 @@ export const useMessageStore = defineStore('message', {
     },
   },
   actions: {
-    /**
-     * Adds an error message.
-     * @param title message title
-     * @param opts an Error, a string containing details, or a MessageOptions
-     */
-    addError(title: string, opts?: Error | string | MessageOptions) {
-      console.error(title, opts);
+    addError(title: string, opts?: ErrorOptions) {
+      console.error(title, opts?.error ?? opts?.details);
 
-      let id: string;
-      if (opts instanceof Error) {
-        id = this._addMessage(
-          {
-            type: MessageType.Error,
-            title,
-          },
-          {
-            details: opts.stack ?? String(opts),
-            persist: false,
-          }
-        );
-      } else {
-        id = this._addMessage(
-          {
-            type: MessageType.Error,
-            title,
-          },
-          opts
-        );
-      }
+      const details =
+        opts?.details ??
+        (opts?.error ? (opts.error.stack ?? String(opts.error)) : undefined);
 
-      this.byID[id].options.bugReport = generateBugReport(opts);
+      const id = this._addMessage(
+        { type: MessageType.Error, title },
+        { details, persist: opts?.persist ?? false }
+      );
+
+      this.byID[id].bugReport = generateBugReport(opts?.error);
 
       return id;
     },

--- a/src/store/remote-save-state.ts
+++ b/src/store/remote-save-state.ts
@@ -30,9 +30,14 @@ const useRemoteSaveStateStore = defineStore('remoteSaveState', () => {
       });
 
       if (saveResult.ok) messageStore.addSuccess('Save Successful');
-      else messageStore.addError('Save Failed', 'Network response not OK');
+      else
+        messageStore.addError('Save Failed', {
+          details: 'Network response not OK',
+        });
     } catch (error) {
-      messageStore.addError('Save Failed with error', `Failed from: ${error}`);
+      messageStore.addError('Save Failed with error', {
+        details: `Failed from: ${error}`,
+      });
     } finally {
       isSaving.value = false;
     }

--- a/src/store/tools/paintProcess.ts
+++ b/src/store/tools/paintProcess.ts
@@ -142,10 +142,9 @@ export const usePaintProcessStore = defineStore('paintProcess', () => {
         showingOriginal: false,
       };
     } catch (error) {
-      messageStore.addError(
-        `${activeProcessType.value} Operation Failed`,
-        error as Error
-      );
+      messageStore.addError(`${activeProcessType.value} Operation Failed`, {
+        error: error as Error,
+      });
       if (processState.value.step === 'computing') {
         rollbackPreview(segImage, originalScalars);
         resetState();

--- a/src/utils/bugReport.ts
+++ b/src/utils/bugReport.ts
@@ -56,10 +56,9 @@ const getSourceFormat = (name: string, isDicom: boolean): string => {
 const formatScalarType = (constructorName: string): string =>
   constructorName.replace('Array', '');
 
-const formatError = (error: unknown): string => {
+const formatError = (error?: Error): string => {
   if (!error) return 'No error details available';
-  const text =
-    error instanceof Error ? (error.stack ?? String(error)) : String(error);
+  const text = error.stack ?? String(error);
   return text.length > MAX_ERROR_LENGTH
     ? `${text.slice(0, MAX_ERROR_LENGTH)}\n... (truncated)`
     : text;
@@ -98,7 +97,7 @@ const collectDatasetInfo = (): string[] => {
   });
 };
 
-export const generateBugReport = (error: unknown): string => {
+export const generateBugReport = (error?: Error): string => {
   const versions = __VERSIONS__;
   const sha = __GIT_SHORT_SHA__;
 

--- a/src/utils/bugReport.ts
+++ b/src/utils/bugReport.ts
@@ -9,40 +9,8 @@ const MAX_ERROR_LENGTH = 4000;
 
 const COMPOUND_EXTENSIONS = ['nii.gz', 'iwi.cbor', 'seg.nrrd'];
 
-const parseBrowserInfo = (): string => {
-  if (typeof navigator === 'undefined') return 'unknown';
-
-  const { userAgent: ua } = navigator;
-
-  const patterns: [string, RegExp][] = [
-    ['Firefox', /Firefox\/([\d.]+)/],
-    ['Edge', /Edg\/([\d.]+)/],
-    ['Chrome', /Chrome\/([\d.]+)/],
-    ['Safari', /Version\/([\d.]+).*Safari/],
-  ];
-
-  const match = patterns
-    .map(([name, re]) => {
-      const m = ua.match(re);
-      return m ? `${name} ${m[1]}` : null;
-    })
-    .find(Boolean);
-
-  const browser = match ?? 'Unknown';
-
-  const os = ['Windows', 'Mac', 'Linux', 'Android', 'iPhone', 'iPad'].find(
-    (name) => ua.includes(name)
-  );
-
-  const osLabel =
-    os === 'Mac'
-      ? 'macos'
-      : os === 'iPhone' || os === 'iPad'
-        ? 'ios'
-        : (os?.toLowerCase() ?? 'unknown');
-
-  return `${browser} (${osLabel})`;
-};
+const getBrowserInfo = (): string =>
+  typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown';
 
 const getSourceFormat = (name: string, isDicom: boolean): string => {
   if (isDicom) return 'DICOM';
@@ -91,7 +59,10 @@ const collectDatasetInfo = (): string[] => {
         : 'unknown';
 
     const segCount = segmentGroupStore.orderByParent[id]?.length ?? 0;
-    const segPart = segCount > 0 ? ` (segment groups: ${segCount})` : '';
+    const segPart =
+      segCount > 0
+        ? ` (segment groups: ${segCount} as ${segmentGroupStore.saveFormat})`
+        : '';
 
     return `  [${i}] ${dims} ${dataType} from ${sourceFormat}${segPart}`;
   });
@@ -104,22 +75,18 @@ export const generateBugReport = (error?: Error): string => {
   const lines = [
     '--- VolView Bug Report ---',
     `Build: volview ${versions.volview} (${sha}) | vtk.js: ${versions['vtk.js']}, itk-wasm: ${versions['itk-wasm']}`,
-    `Browser: ${parseBrowserInfo()}`,
+    `Browser: ${getBrowserInfo()}`,
     '',
     'Error:',
     formatError(error),
   ];
 
-  try {
-    const datasets = collectDatasetInfo();
-    const segmentGroupStore = useSegmentGroupStore();
+  const datasets = collectDatasetInfo();
+  const segmentGroupStore = useSegmentGroupStore();
 
-    lines.push('', `Datasets: ${datasets.length}`);
-    lines.push(...datasets);
-    lines.push(`Save format: ${segmentGroupStore.saveFormat}`);
-  } catch {
-    lines.push('', 'Datasets: unavailable');
-  }
+  lines.push('', `Datasets: ${datasets.length}`);
+  lines.push(...datasets);
+  lines.push(`Save format: ${segmentGroupStore.saveFormat}`);
 
   lines.push('--- End Report ---');
 

--- a/src/utils/bugReport.ts
+++ b/src/utils/bugReport.ts
@@ -1,0 +1,128 @@
+/* global __VERSIONS__, __GIT_SHORT_SHA__ */
+
+import { useDatasetStore } from '@/src/store/datasets';
+import { useDICOMStore } from '@/src/store/datasets-dicom';
+import { useImageCacheStore } from '@/src/store/image-cache';
+import { useSegmentGroupStore } from '@/src/store/segmentGroups';
+
+const MAX_ERROR_LENGTH = 4000;
+
+const COMPOUND_EXTENSIONS = ['nii.gz', 'iwi.cbor', 'seg.nrrd'];
+
+const parseBrowserInfo = (): string => {
+  if (typeof navigator === 'undefined') return 'unknown';
+
+  const { userAgent: ua } = navigator;
+
+  const patterns: [string, RegExp][] = [
+    ['Firefox', /Firefox\/([\d.]+)/],
+    ['Edge', /Edg\/([\d.]+)/],
+    ['Chrome', /Chrome\/([\d.]+)/],
+    ['Safari', /Version\/([\d.]+).*Safari/],
+  ];
+
+  const match = patterns
+    .map(([name, re]) => {
+      const m = ua.match(re);
+      return m ? `${name} ${m[1]}` : null;
+    })
+    .find(Boolean);
+
+  const browser = match ?? 'Unknown';
+
+  const os = ['Windows', 'Mac', 'Linux', 'Android', 'iPhone', 'iPad'].find(
+    (name) => ua.includes(name)
+  );
+
+  const osLabel =
+    os === 'Mac'
+      ? 'macos'
+      : os === 'iPhone' || os === 'iPad'
+        ? 'ios'
+        : (os?.toLowerCase() ?? 'unknown');
+
+  return `${browser} (${osLabel})`;
+};
+
+const getSourceFormat = (name: string, isDicom: boolean): string => {
+  if (isDicom) return 'DICOM';
+  const lower = name.toLowerCase();
+  const compound = COMPOUND_EXTENSIONS.find((ext) => lower.endsWith(`.${ext}`));
+  if (compound) return compound;
+  const lastDot = name.lastIndexOf('.');
+  return lastDot >= 0 ? name.slice(lastDot + 1).toLowerCase() : 'unknown';
+};
+
+const formatScalarType = (constructorName: string): string =>
+  constructorName.replace('Array', '');
+
+const formatError = (error: unknown): string => {
+  if (!error) return 'No error details available';
+  const text =
+    error instanceof Error ? (error.stack ?? String(error)) : String(error);
+  return text.length > MAX_ERROR_LENGTH
+    ? `${text.slice(0, MAX_ERROR_LENGTH)}\n... (truncated)`
+    : text;
+};
+
+const collectDatasetInfo = (): string[] => {
+  const datasetStore = useDatasetStore();
+  const imageCacheStore = useImageCacheStore();
+  const dicomStore = useDICOMStore();
+  const segmentGroupStore = useSegmentGroupStore();
+
+  return datasetStore.idsAsSelections.map((id, i) => {
+    const metadata = imageCacheStore.getImageMetadata(id);
+    const imageData = imageCacheStore.getVtkImageData(id);
+
+    const dims = metadata
+      ? Array.from(metadata.dimensions).join('\u00d7')
+      : 'unknown';
+
+    const scalars = imageData?.getPointData().getScalars()?.getData();
+    const dataType = scalars
+      ? formatScalarType(scalars.constructor.name)
+      : 'unknown';
+
+    const isDicom = id in dicomStore.volumeInfo;
+    const sourceFormat = metadata
+      ? getSourceFormat(metadata.name, isDicom)
+      : isDicom
+        ? 'DICOM'
+        : 'unknown';
+
+    const segCount = segmentGroupStore.orderByParent[id]?.length ?? 0;
+    const segPart = segCount > 0 ? ` (segment groups: ${segCount})` : '';
+
+    return `  [${i}] ${dims} ${dataType} from ${sourceFormat}${segPart}`;
+  });
+};
+
+export const generateBugReport = (error: unknown): string => {
+  const versions = __VERSIONS__;
+  const sha = __GIT_SHORT_SHA__;
+
+  const lines = [
+    '--- VolView Bug Report ---',
+    `Build: volview ${versions.volview} (${sha}) | vtk.js: ${versions['vtk.js']}, itk-wasm: ${versions['itk-wasm']}`,
+    `Browser: ${parseBrowserInfo()}`,
+    '',
+    'Error:',
+    formatError(error),
+  ];
+
+  try {
+    const datasets = collectDatasetInfo();
+    const segmentGroupStore = useSegmentGroupStore();
+
+    lines.push('', `Datasets: ${datasets.length}`);
+    lines.push(...datasets);
+    lines.push(`Save format: ${segmentGroupStore.saveFormat}`);
+  } catch {
+    lines.push('', 'Datasets: unavailable');
+  }
+
+  lines.push('--- End Report ---');
+
+  return lines.join('\n');
+};

--- a/tests/specs/bug-report.e2e.ts
+++ b/tests/specs/bug-report.e2e.ts
@@ -2,7 +2,7 @@ import { volViewPage } from '../pageobjects/volview.page';
 import { writeManifestToFile } from './utils';
 
 describe('Bug report generation', () => {
-  it('should show Copy Bug Report button on error with stack trace details', async () => {
+  it('should attach bug report to error messages', async () => {
     // Trigger an error by loading a malformed URL
     const manifest = { resources: [{ url: 'bad-url-to-trigger-error' }] };
     await writeManifestToFile(manifest, 'bugReportTest.json');
@@ -14,7 +14,7 @@ describe('Bug report generation', () => {
     const notificationBadge = volViewPage.notifications;
     await notificationBadge.click();
 
-    // Wait for the message center dialog and the Copy Bug Report button in the title
+    // Wait for the Copy Bug Report button to appear
     await browser.waitUntil(
       async () => {
         const btn = await $('[data-testid="copy-bug-report-button"]');
@@ -23,19 +23,19 @@ describe('Bug report generation', () => {
       { timeout: 5000, timeoutMsg: 'Expected Copy Bug Report button' }
     );
 
-    // Expand the error message to reveal details
-    const panelTitle = await $('.v-expansion-panel-title');
-    await panelTitle.click();
+    // Verify bug report content via the store
+    const report = await browser.execute(() => {
+      // Access the Pinia store from the app instance
+      const app = document.querySelector('#app') as any;
+      const pinia = app?.__vue_app__?.config?.globalProperties?.$pinia;
+      if (!pinia) return '';
+      const store = pinia.state.value.message;
+      if (!store) return '';
+      const firstId = store.msgList[0];
+      return store.byID[firstId]?.bugReport ?? '';
+    });
 
-    // Verify the error details with stack trace are shown
-    await browser.waitUntil(
-      async () => {
-        const details = await $('.details');
-        if (!(await details.isExisting())) return false;
-        const text = await details.getText();
-        return text.length > 0;
-      },
-      { timeout: 3000, timeoutMsg: 'Expected error details with stack trace' }
-    );
+    expect(report).toContain('--- VolView Bug Report ---');
+    expect(report).toContain('Browser:');
   });
 });

--- a/tests/specs/bug-report.e2e.ts
+++ b/tests/specs/bug-report.e2e.ts
@@ -1,0 +1,41 @@
+import { volViewPage } from '../pageobjects/volview.page';
+import { writeManifestToFile } from './utils';
+
+describe('Bug report generation', () => {
+  it('should show Copy Bug Report button on error with stack trace details', async () => {
+    // Trigger an error by loading a malformed URL
+    const manifest = { resources: [{ url: 'bad-url-to-trigger-error' }] };
+    await writeManifestToFile(manifest, 'bugReportTest.json');
+    await volViewPage.open('?urls=[tmp/bugReportTest.json]');
+
+    await volViewPage.waitForNotification();
+
+    // Click the notifications badge to open the message center
+    const notificationBadge = volViewPage.notifications;
+    await notificationBadge.click();
+
+    // Wait for the message center dialog and the Copy Bug Report button in the title
+    await browser.waitUntil(
+      async () => {
+        const btn = await $('[data-testid="copy-bug-report-button"]');
+        return btn.isDisplayed();
+      },
+      { timeout: 5000, timeoutMsg: 'Expected Copy Bug Report button' }
+    );
+
+    // Expand the error message to reveal details
+    const panelTitle = await $('.v-expansion-panel-title');
+    await panelTitle.click();
+
+    // Verify the error details with stack trace are shown
+    await browser.waitUntil(
+      async () => {
+        const details = await $('.details');
+        if (!(await details.isExisting())) return false;
+        const text = await details.getText();
+        return text.length > 0;
+      },
+      { timeout: 3000, timeoutMsg: 'Expected error details with stack trace' }
+    );
+  });
+});

--- a/tests/specs/bug-report.e2e.ts
+++ b/tests/specs/bug-report.e2e.ts
@@ -2,7 +2,7 @@ import { volViewPage } from '../pageobjects/volview.page';
 import { writeManifestToFile } from './utils';
 
 describe('Bug report generation', () => {
-  it('should attach bug report to error messages', async () => {
+  it('should show Copy Bug Report button on error', async () => {
     // Trigger an error by loading a malformed URL
     const manifest = { resources: [{ url: 'bad-url-to-trigger-error' }] };
     await writeManifestToFile(manifest, 'bugReportTest.json');
@@ -22,20 +22,5 @@ describe('Bug report generation', () => {
       },
       { timeout: 5000, timeoutMsg: 'Expected Copy Bug Report button' }
     );
-
-    // Verify bug report content via the store
-    const report = await browser.execute(() => {
-      // Access the Pinia store from the app instance
-      const app = document.querySelector('#app') as any;
-      const pinia = app?.__vue_app__?.config?.globalProperties?.$pinia;
-      if (!pinia) return '';
-      const store = pinia.state.value.message;
-      if (!store) return '';
-      const firstId = store.msgList[0];
-      return store.byID[firstId]?.bugReport ?? '';
-    });
-
-    expect(report).toContain('--- VolView Bug Report ---');
-    expect(report).toContain('Browser:');
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest" />
 import * as path from 'node:path';
 import * as fs from 'node:fs';
+import { execSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { Plugin, defineConfig, normalizePath } from 'vite';
 import vue from '@vitejs/plugin-vue';
@@ -54,6 +55,14 @@ function getPackageInfo() {
   };
 }
 
+function getGitShortSha() {
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
 const rootDir = resolvePath(__dirname);
 const distDir = resolvePath(rootDir, 'dist');
 
@@ -101,6 +110,7 @@ export default defineConfig({
       'vtk.js': pkgInfo.versions['vtk.js'],
       'itk-wasm': pkgInfo.versions['itk-wasm'],
     },
+    __GIT_SHORT_SHA__: JSON.stringify(getGitShortSha()),
   },
   resolve: {
     alias: [

--- a/wdio.chrome.conf.ts
+++ b/wdio.chrome.conf.ts
@@ -6,7 +6,8 @@ if (process.env.CI || process.env.GITHUB_ACTIONS) {
   chromeArgs.push(
     '--no-sandbox',
     '--disable-dev-shm-usage',
-    '--disable-infobars'
+    '--disable-infobars',
+    '--enable-unsafe-swiftshader'
   );
 }
 


### PR DESCRIPTION
Generate a structured, anonymous bug report (build info, browser, stack trace, dataset metadata) on every error and attach it to the message. Users can copy it to clipboard via a button in the notification center.

Also tightens the types of the error message options with `ErrorOptions` to avoid a type union and sniffing around with `instanceof` in message.ts which was causing some errors to get unhelpfuly stringified as `object Object`.

<img width="571" height="279" alt="image" src="https://github.com/user-attachments/assets/3aaa564c-10b2-45f5-b31e-dac857608368" />


closes #854