### PR TITLE
chore: run prettier in lint-staged pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,8 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,vue}": [
-      "eslint"
+      "eslint",
+      "prettier --config ./prettier.config.cjs --write"
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Add prettier to the lint-staged pre-commit hook so staged files are auto-formatted at commit time.
- Mirrors the `prettier --list-different` check CI runs, preventing formatting-only CI failures (e.g. seen on #863).

## Test plan
- [ ] Stage a file with intentional formatting drift and commit; verify prettier reformats it before the commit lands.
- [ ] Confirm CI's prettier step passes on this branch.