### PR TITLE
fix(s3): percent-encode object keys in download URLs

### DIFF
--- a/src/io/__tests__/amazonS3.spec.ts
+++ b/src/io/__tests__/amazonS3.spec.ts
@@ -77,6 +77,33 @@ describe('amazonS3', () => {
       expect(init).toBeUndefined();
     });
 
+    it('percent-encodes reserved chars in keys but preserves slashes', async () => {
+      fetchSpy.mockResolvedValueOnce(
+        okResponse(
+          xmlListResponse([
+            'scan?1.dcm',
+            'seg#1.dcm',
+            'my scan.dcm',
+            'a+b.dcm',
+            'sub/dir/file.dcm',
+          ])
+        )
+      );
+
+      const urls: string[] = [];
+      await getObjectsFromS3('s3://bucket/prefix', (_name, url) =>
+        urls.push(url)
+      );
+
+      expect(urls).toEqual([
+        'https://bucket.s3.amazonaws.com/scan%3F1.dcm',
+        'https://bucket.s3.amazonaws.com/seg%231.dcm',
+        'https://bucket.s3.amazonaws.com/my%20scan.dcm',
+        'https://bucket.s3.amazonaws.com/a%2Bb.dcm',
+        'https://bucket.s3.amazonaws.com/sub/dir/file.dcm',
+      ]);
+    });
+
     it('follows pagination via continuation token', async () => {
       fetchSpy
         .mockResolvedValueOnce(

--- a/src/io/amazonS3.ts
+++ b/src/io/amazonS3.ts
@@ -10,8 +10,13 @@ export const isAmazonS3Uri = (uri: string) =>
 
 export type ObjectAvailableCallback = (name: string, url: string) => void;
 
+// Percent-encode each path segment so keys containing reserved URI chars
+// (`?`, `#`, space, `+`, …) round-trip correctly. Slashes are preserved.
+const encodeS3Key = (key: string) =>
+  key.split('/').map(encodeURIComponent).join('/');
+
 const getObjectPublicUrl = (bucket: string, key: string) =>
-  `https://${bucket}.s3.amazonaws.com/${key}`;
+  `https://${bucket}.s3.amazonaws.com/${encodeS3Key(key)}`;
 
 const buildListUrl = (
   bucket: string,


### PR DESCRIPTION
S3 keys may contain `?`, `#`, space, `+`, etc. (per AWS object-key rules), and `ListObjectsV2` returns them verbatim. `getObjectPublicUrl` interpolated keys raw, so e.g. `scan?1.dcm` was sent as `GET /scan?1.dcm` (404) and `seg#1.dcm` lost its `#1.dcm` to the fragment.

Split on `/`, `encodeURIComponent` each segment. Tests cover `?`, `#`, space, `+`, and a multi-segment key.