### PR TITLE
test(e2e): stabilize software-rendered browser runs

### DIFF
--- a/tests/specs/layers-and-rendering.e2e.ts
+++ b/tests/specs/layers-and-rendering.e2e.ts
@@ -46,14 +46,28 @@ describe('Layers and Rendering', () => {
       }
     );
 
-    const menus = await volViewPage.datasetMenuButtons;
-    const menuCount = await menus.length;
-    if (menuCount < 2) {
-      throw new Error(
-        `Expected at least 2 dataset menu buttons, but found ${menuCount}`
-      );
-    }
-    await menus[1].click();
+    const inactiveMenuSelector =
+      '.volume-card:not(.volume-card-active) button[data-testid="dataset-menu-button"]';
+
+    await browser.waitUntil(
+      async () => {
+        const activeMenus = await $$(
+          '.volume-card-active button[data-testid="dataset-menu-button"]'
+        );
+        const inactiveMenus = await $$(inactiveMenuSelector);
+        return (
+          (await activeMenus.length) >= 1 && (await inactiveMenus.length) >= 1
+        );
+      },
+      {
+        timeout: DOWNLOAD_TIMEOUT,
+        timeoutMsg:
+          'Expected active and inactive datasets to be available for layering',
+      }
+    );
+
+    const inactiveMenus = await $$(inactiveMenuSelector);
+    await inactiveMenus[0].click();
 
     await browser.waitUntil(
       async () => {
@@ -62,7 +76,10 @@ describe('Layers and Rendering', () => {
         );
         return addLayerButton.isClickable();
       },
-      { timeoutMsg: 'Expected clickable Add Layer button' }
+      {
+        timeout: DOWNLOAD_TIMEOUT,
+        timeoutMsg: 'Expected clickable Add Layer button',
+      }
     );
 
     const addLayerButton = await $(

--- a/wdio.shared.conf.ts
+++ b/wdio.shared.conf.ts
@@ -41,7 +41,7 @@ export const applyTestViewport = (browser: any) =>
 export const TEST_PORT = 4567;
 // for slow connections try:
 // DOWNLOAD_TIMEOUT=60000 && npm run test:e2e:dev
-export const DOWNLOAD_TIMEOUT = Number(process.env.DOWNLOAD_TIMEOUT ?? 20000);
+export const DOWNLOAD_TIMEOUT = Number(process.env.DOWNLOAD_TIMEOUT ?? 30000);
 
 const IS_CI = !!(process.env.CI || process.env.GITHUB_ACTIONS);
 
@@ -68,7 +68,9 @@ export const config: Options.Testrunner = {
   // ============
   // Capabilities
   // ============
-  maxInstances: IS_CI ? 1 : 6,
+  // WebGL rendering is resource-intensive enough that six local Chrome
+  // instances can starve one another and exceed view-rendering timeouts.
+  maxInstances: IS_CI ? 1 : 3,
   //
   // ===================
   // Test Configurations


### PR DESCRIPTION
## What changed

- Reduce local e2e concurrency from six Chrome instances to three.
- Restore the default render/download timeout from 20 to 30 seconds.
- Make the layer overlay test wait for an active dataset and open a different dataset's menu before selecting **Add Layer**.
- Leave the existing Linux Xvfb and Chrome renderer configuration unchanged.

## Why

Six software-rendered Chrome instances can starve the browser and WebDriver long enough for otherwise healthy views to exceed the 20-second render timeout. Timed-out pages recovered without a reload once CPU pressure eased. CI already runs one instance and sets `DOWNLOAD_TIMEOUT=90000`, so these concurrency and default-timeout changes are local-only.

The first CI run for this PR exposed a separate race in `layers-and-rendering.e2e.ts`. The test waited for two dataset menus, then always opened the second menu. **Add Layer** is only available after a primary dataset is active and only on a different dataset, so the test could wait for an element that should not exist. It now waits for both active and inactive datasets and opens an inactive dataset's menu.

The Linux GL backend experiment was removed from this PR so renderer changes can be evaluated independently.

## Tested

- `npm run test:e2e:chrome` — 30/30 spec files passed with three local Chrome instances
- `layers-and-rendering.e2e.ts` under the existing CI-style Xvfb configuration — 10 consecutive passes
- `npm run lint`
- Prettier and `git diff --check`
