### PR TITLE
build(version): derive app version from git tag when package.json is a placeholder

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -9,7 +9,9 @@
   VITE_SHOW_SAMPLE_DATA= "true"
 
 [build]
-command = "sed -i \"s|DICOM_WEB_API_KEY|${DICOM_WEB_API_KEY}|g; s|DICOM_WEB_ADDRESS|${DICOM_WEB_ADDRESS}|g\" netlify.toml && npm run build"
+# The version shown in the About box comes from `git describe`, which needs tags
+# and enough history to count from them. Netlify clones neither by default.
+command = "{ git fetch --tags --unshallow || git fetch --tags; } 2>/dev/null; sed -i \"s|DICOM_WEB_API_KEY|${DICOM_WEB_API_KEY}|g; s|DICOM_WEB_ADDRESS|${DICOM_WEB_ADDRESS}|g\" netlify.toml && npm run build"
 
 [dev]
 targetPort = 8080

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,8 @@ function resolvePath(...args: string[]) {
   return normalizePath(path.resolve(...args));
 }
 
+const PLACEHOLDER_VERSION = '0.0.0';
+
 function getPackageInfo() {
   const mainPkgPath = path.resolve(__dirname, 'package.json');
   const mainPkg = JSON.parse(fs.readFileSync(mainPkgPath, 'utf-8'));
@@ -48,11 +50,30 @@ function getPackageInfo() {
 
   return {
     versions: {
-      volview: mainPkg.version,
+      volview: getVolViewVersion(mainPkg.version),
       'vtk.js': vtkJsPkg.version,
       'itk-wasm': itkWasmPkg.version,
     },
   };
+}
+
+// package.json carries the placeholder 0.0.0 on main; the release workflow
+// stamps the real version from the pushed tag before it builds. Builds that
+// skip that step (Netlify, local dev) fall back to describing the tag directly.
+function getVolViewVersion(pkgVersion: string) {
+  if (pkgVersion !== PLACEHOLDER_VERSION) return pkgVersion;
+  return getGitDescribe() ?? pkgVersion;
+}
+
+function getGitDescribe() {
+  try {
+    const described = execSync('git describe --tags --always')
+      .toString()
+      .trim();
+    return described.replace(/^v/, '');
+  } catch {
+    return undefined;
+  }
 }
 
 function getGitShortSha() {


### PR DESCRIPTION
The About box and bug report link read `__VERSIONS__.volview`, which came straight from `package.json`. Since `main` pins the version to `0.0.0` (the release workflow stamps the real version only in the CI checkout), every non-publish build showed `0.0.0`.

This keeps `package.json` at `0.0.0` and instead falls back to `git describe --tags` in `vite.config.ts` when the version is the placeholder. When CI has already stamped a real version, that value still wins, so published npm tarballs are unchanged.

Netlify clones shallow and without tags, so `git describe` had nothing to work with (verified with a `--depth 1` clone: describe degrades to a bare sha). The second commit adds a tag fetch to the Netlify build command, tolerant of both shallow and complete repos, and non-fatal if the fetch fails.

Resulting version shown per build:

| Build | package.json at build | About box |
| --- | --- | --- |
| npm tag release | stamped by CI | tag version |
| npm dev prerelease | stamped by CI | matches published |
| Netlify / local | 0.0.0 | `git describe`, e.g. `4.4.1-152-g38d39f96` |

With this, no release needs a version bump commit; the git tag is the single source of truth.