### PR TITLE
fix(vtk): stop renders and release resources when a view is torn down

### DIFF
--- a/src/components/tools/SelectTool.vue
+++ b/src/components/tools/SelectTool.vue
@@ -45,6 +45,8 @@ onVTKEvent(
     // position or, mid capture, nothing at all.
     const { x, y } = event.position;
     const selectedData = await view.widgetManager.getSelectedDataForXY(x, y);
+    // the pick spans a capture, which the view teardown can outrun
+    if (view.widgetManager.isDeleted()) return;
     if ('widget' in selectedData) {
       const widget =
         selectedData.widget as Partial<vtkAnnotationToolWidget> | null;

--- a/src/components/vtk/VtkRenderWindowParent.vue
+++ b/src/components/vtk/VtkRenderWindowParent.vue
@@ -1,8 +1,9 @@
 <script setup lang="ts">
 import { VtkRenderWindowParentContext } from '@/src/components/vtk/context';
+import { releaseOpenGLRenderWindow } from '@/src/core/vtk/releaseRenderWindow';
 import vtkRenderWindow from '@kitware/vtk.js/Rendering/Core/RenderWindow';
 import vtkOpenGLRenderWindow from '@kitware/vtk.js/Rendering/OpenGL/RenderWindow';
-import { effectScope, onUnmounted, provide } from 'vue';
+import { effectScope, onScopeDispose, onUnmounted, provide } from 'vue';
 
 const scope = effectScope(true);
 
@@ -11,6 +12,14 @@ const api = scope.run(() => {
   const rwView = renderWindow.newAPISpecificView('WebGL');
   renderWindow.addView(rwView);
   rwView.initialize();
+
+  // Child views unmount before this hook runs, so their nodes are already off
+  // the scene graph by the time the WebGL context they draw through goes away.
+  onScopeDispose(() => {
+    renderWindow.removeView(rwView);
+    releaseOpenGLRenderWindow(rwView as vtkOpenGLRenderWindow);
+    renderWindow.delete();
+  });
 
   return {
     renderWindow,

--- a/src/composables/__tests__/useVolumeThumbnailing.spec.ts
+++ b/src/composables/__tests__/useVolumeThumbnailing.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, beforeEach } from 'vitest';
+import { createPinia, setActivePinia } from 'pinia';
+import { defineComponent, h } from 'vue';
+import { mount } from '@vue/test-utils';
+import { useVolumeThumbnailing } from '@/src/composables/useVolumeThumbnailing';
+import type { createVolumeThumbnailer } from '@/src/core/thumbnailers/volume-thumbnailer';
+
+type Thumbnailer = ReturnType<typeof createVolumeThumbnailer>;
+
+// the real thumbnailer needs a WebGL context the test DOM cannot provide; none
+// of its rendering surface is reached until an image loads, which this does not
+function createStubThumbnailer() {
+  let deleted = false;
+  const thumbnailer = {
+    delete() {
+      deleted = true;
+    },
+  };
+  return {
+    thumbnailer: thumbnailer as unknown as Thumbnailer,
+    isDeleted: () => deleted,
+  };
+}
+
+describe('useVolumeThumbnailing', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  it('disposes the thumbnailer when the component unmounts', () => {
+    const stub = createStubThumbnailer();
+    const component = defineComponent({
+      setup() {
+        useVolumeThumbnailing(64, () => stub.thumbnailer);
+        return () => h('div');
+      },
+    });
+
+    const wrapper = mount(component);
+    expect(stub.isDeleted()).toBe(false);
+
+    wrapper.unmount();
+
+    expect(stub.isDeleted()).toBe(true);
+  });
+});

--- a/src/composables/__tests__/useVolumeThumbnailing.spec.ts
+++ b/src/composables/__tests__/useVolumeThumbnailing.spec.ts
@@ -1,17 +1,44 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
-import { defineComponent, h } from 'vue';
-import { mount } from '@vue/test-utils';
+import { defineComponent, h, ref } from 'vue';
+import { flushPromises, mount } from '@vue/test-utils';
+import vtkImageData from '@kitware/vtk.js/Common/DataModel/ImageData';
+import vtkDataArray from '@kitware/vtk.js/Common/Core/DataArray';
 import { useVolumeThumbnailing } from '@/src/composables/useVolumeThumbnailing';
+import { CurrentImageInjectionKey } from '@/src/composables/useCurrentImage';
+import { useImageCacheStore } from '@/src/store/image-cache';
+import { NOOP } from '@/src/constants';
 import type { createVolumeThumbnailer } from '@/src/core/thumbnailers/volume-thumbnailer';
 
 type Thumbnailer = ReturnType<typeof createVolumeThumbnailer>;
 
-// the real thumbnailer needs a WebGL context the test DOM cannot provide; none
-// of its rendering surface is reached until an image loads, which this does not
-function createStubThumbnailer() {
+const IMAGE_ID = 'img-1';
+
+// the real thumbnailer needs a WebGL context the test DOM cannot provide, so
+// this stands in for the surface the composable touches
+function createStubThumbnailer(capture?: Promise<string>) {
   let deleted = false;
+  let captureCount = 0;
+  const noopProxy = {
+    setDataRange: NOOP,
+    setMode: NOOP,
+    setPoints: NOOP,
+    setGaussians: NOOP,
+    setPresetName: NOOP,
+  };
+  const renderWindow = {
+    render: NOOP,
+    captureImages: () => {
+      captureCount += 1;
+      return [capture ?? Promise.resolve('')];
+    },
+  };
   const thumbnailer = {
+    scene: { getRenderWindow: () => renderWindow },
+    opacityFuncProxy: noopProxy,
+    colorTransferFuncProxy: noopProxy,
+    setInputImage: NOOP,
+    resetCameraWithOrientation: NOOP,
     delete() {
       deleted = true;
     },
@@ -19,7 +46,33 @@ function createStubThumbnailer() {
   return {
     thumbnailer: thumbnailer as unknown as Thumbnailer,
     isDeleted: () => deleted,
+    getCaptureCount: () => captureCount,
   };
+}
+
+function addImageToCache() {
+  const image = vtkImageData.newInstance();
+  image.setDimensions([2, 2, 2]);
+  image
+    .getPointData()
+    .setScalars(vtkDataArray.newInstance({ values: new Uint8Array(8) }));
+  useImageCacheStore().addVTKImageData(image, 'CT', { id: IMAGE_ID });
+}
+
+function mountThumbnailing(thumbnailer: Thumbnailer, imageID: string | null) {
+  const component = defineComponent({
+    setup() {
+      useVolumeThumbnailing(64, () => thumbnailer);
+      return () => h('div');
+    },
+  });
+  return mount(component, {
+    global: {
+      provide: {
+        [CurrentImageInjectionKey as symbol]: { imageID: ref(imageID) },
+      },
+    },
+  });
 }
 
 describe('useVolumeThumbnailing', () => {
@@ -27,20 +80,40 @@ describe('useVolumeThumbnailing', () => {
     setActivePinia(createPinia());
   });
 
-  it('disposes the thumbnailer when the component unmounts', () => {
+  it('disposes the thumbnailer when the component unmounts', async () => {
     const stub = createStubThumbnailer();
-    const component = defineComponent({
-      setup() {
-        useVolumeThumbnailing(64, () => stub.thumbnailer);
-        return () => h('div');
-      },
-    });
-
-    const wrapper = mount(component);
+    const wrapper = mountThumbnailing(stub.thumbnailer, null);
     expect(stub.isDeleted()).toBe(false);
 
     wrapper.unmount();
+    await flushPromises();
 
     expect(stub.isDeleted()).toBe(true);
+  });
+
+  it('holds off deletion until an in-flight capture settles', async () => {
+    let resolveCapture!: (uri: string) => void;
+    const capture = new Promise<string>((resolve) => {
+      resolveCapture = resolve;
+    });
+    const stub = createStubThumbnailer(capture);
+    addImageToCache();
+
+    const wrapper = mountThumbnailing(stub.thumbnailer, IMAGE_ID);
+    await flushPromises();
+    expect(stub.getCaptureCount()).toBe(1);
+
+    // captureImages() finishes its render on a timer, so deleting the render
+    // window while the capture is pending would crash that callback.
+    wrapper.unmount();
+    await flushPromises();
+    expect(stub.isDeleted()).toBe(false);
+
+    resolveCapture('data:image/png;base64,');
+    await flushPromises();
+    expect(stub.isDeleted()).toBe(true);
+
+    // the unmount sentinel keeps the remaining presets from capturing
+    expect(stub.getCaptureCount()).toBe(1);
   });
 });

--- a/src/composables/__tests__/useVolumeThumbnailing.spec.ts
+++ b/src/composables/__tests__/useVolumeThumbnailing.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 import { createPinia, setActivePinia } from 'pinia';
-import { defineComponent, h, ref } from 'vue';
+import { defineComponent, h, ref, type Ref } from 'vue';
 import { flushPromises, mount } from '@vue/test-utils';
 import vtkImageData from '@kitware/vtk.js/Common/DataModel/ImageData';
 import vtkDataArray from '@kitware/vtk.js/Common/Core/DataArray';
@@ -13,6 +13,7 @@ import type { createVolumeThumbnailer } from '@/src/core/thumbnailers/volume-thu
 type Thumbnailer = ReturnType<typeof createVolumeThumbnailer>;
 
 const IMAGE_ID = 'img-1';
+const OTHER_IMAGE_ID = 'img-2';
 
 // the real thumbnailer needs a WebGL context the test DOM cannot provide, so
 // this stands in for the surface the composable touches
@@ -50,16 +51,19 @@ function createStubThumbnailer(capture?: Promise<string>) {
   };
 }
 
-function addImageToCache() {
+function addImageToCache(id = IMAGE_ID) {
   const image = vtkImageData.newInstance();
   image.setDimensions([2, 2, 2]);
   image
     .getPointData()
     .setScalars(vtkDataArray.newInstance({ values: new Uint8Array(8) }));
-  useImageCacheStore().addVTKImageData(image, 'CT', { id: IMAGE_ID });
+  useImageCacheStore().addVTKImageData(image, 'CT', { id });
 }
 
-function mountThumbnailing(thumbnailer: Thumbnailer, imageID: string | null) {
+function mountThumbnailing(
+  thumbnailer: Thumbnailer,
+  imageID: Ref<string | null>
+) {
   const component = defineComponent({
     setup() {
       useVolumeThumbnailing(64, () => thumbnailer);
@@ -69,7 +73,7 @@ function mountThumbnailing(thumbnailer: Thumbnailer, imageID: string | null) {
   return mount(component, {
     global: {
       provide: {
-        [CurrentImageInjectionKey as symbol]: { imageID: ref(imageID) },
+        [CurrentImageInjectionKey as symbol]: { imageID },
       },
     },
   });
@@ -82,7 +86,7 @@ describe('useVolumeThumbnailing', () => {
 
   it('disposes the thumbnailer when the component unmounts', async () => {
     const stub = createStubThumbnailer();
-    const wrapper = mountThumbnailing(stub.thumbnailer, null);
+    const wrapper = mountThumbnailing(stub.thumbnailer, ref(null));
     expect(stub.isDeleted()).toBe(false);
 
     wrapper.unmount();
@@ -99,7 +103,7 @@ describe('useVolumeThumbnailing', () => {
     const stub = createStubThumbnailer(capture);
     addImageToCache();
 
-    const wrapper = mountThumbnailing(stub.thumbnailer, IMAGE_ID);
+    const wrapper = mountThumbnailing(stub.thumbnailer, ref(IMAGE_ID));
     await flushPromises();
     expect(stub.getCaptureCount()).toBe(1);
 
@@ -115,5 +119,21 @@ describe('useVolumeThumbnailing', () => {
 
     // the unmount sentinel keeps the remaining presets from capturing
     expect(stub.getCaptureCount()).toBe(1);
+  });
+
+  it('starts a new cycle even while an earlier capture never settles', async () => {
+    const stub = createStubThumbnailer(new Promise<string>(() => {}));
+    addImageToCache();
+    addImageToCache(OTHER_IMAGE_ID);
+    const imageID = ref<string | null>(IMAGE_ID);
+
+    mountThumbnailing(stub.thumbnailer, imageID);
+    await flushPromises();
+    expect(stub.getCaptureCount()).toBe(1);
+
+    imageID.value = OTHER_IMAGE_ID;
+    await flushPromises();
+
+    expect(stub.getCaptureCount()).toBeGreaterThan(1);
   });
 });

--- a/src/composables/useVolumeThumbnailing.ts
+++ b/src/composables/useVolumeThumbnailing.ts
@@ -65,6 +65,10 @@ export function useVolumeThumbnailing(
   // doThumbnailing is called again
   let interruptSentinel = Symbol('interrupt');
 
+  // captureImages() finishes its render on a timer, so the render window has to
+  // outlive every in-flight capture; this chain tracks them for unmount
+  let activeThumbnailing = Promise.resolve();
+
   async function doThumbnailing(imageID: string, image: vtkImageData) {
     const localSentinel = Symbol('interrupt');
     interruptSentinel = localSentinel;
@@ -118,10 +122,12 @@ export function useVolumeThumbnailing(
       }
     }
 
-    PresetNameList.reduce(
+    // chaining off the previous cycle keeps a capture it still has in flight
+    // covered by the tracking promise; its presets bail out through the sentinel
+    activeThumbnailing = PresetNameList.reduce(
       (promise, presetName) => promise.then(() => helper(presetName)),
-      Promise.resolve()
-    );
+      activeThumbnailing
+    ).catch(logError);
   }
 
   // workaround for computed not properly working on deeply reactive objects
@@ -139,13 +145,7 @@ export function useVolumeThumbnailing(
   // force thumbnailing to stop
   onBeforeUnmount(() => {
     interruptSentinel = Symbol('unmount');
-    // the thumbnailer owns a WebGL context and this composable remounts with
-    // the rendering panel, so a failed teardown must not abort the unmount
-    try {
-      thumbnailer.delete();
-    } catch (err) {
-      logError(err);
-    }
+    activeThumbnailing.finally(() => thumbnailer.delete()).catch(logError);
   });
 
   // trigger thumbnailing

--- a/src/composables/useVolumeThumbnailing.ts
+++ b/src/composables/useVolumeThumbnailing.ts
@@ -13,6 +13,7 @@ import {
   getOpacityRangeFromPreset,
 } from '../utils/vtk-helpers';
 import { PresetNameList } from '../vtk/ColorMaps';
+import { logError } from '../utils/loggers';
 
 function resetOpacityFunction(
   pwfProxy: vtkPiecewiseFunctionProxy,
@@ -42,9 +43,12 @@ function resetOpacityFunction(
   }
 }
 
-export function useVolumeThumbnailing(thumbnailSize: number) {
+export function useVolumeThumbnailing(
+  thumbnailSize: number,
+  createThumbnailer = createVolumeThumbnailer
+) {
   const thumbnails = reactive<Record<string, Record<string, string>>>({});
-  const thumbnailer = createVolumeThumbnailer(thumbnailSize);
+  const thumbnailer = createThumbnailer(thumbnailSize);
   const currentThumbnails = ref<Record<string, string>>({});
 
   const { currentImageMetadata, currentImageID, currentImageData } =
@@ -135,6 +139,13 @@ export function useVolumeThumbnailing(thumbnailSize: number) {
   // force thumbnailing to stop
   onBeforeUnmount(() => {
     interruptSentinel = Symbol('unmount');
+    // the thumbnailer owns a WebGL context and this composable remounts with
+    // the rendering panel, so a failed teardown must not abort the unmount
+    try {
+      thumbnailer.delete();
+    } catch (err) {
+      logError(err);
+    }
   });
 
   // trigger thumbnailing

--- a/src/composables/useVolumeThumbnailing.ts
+++ b/src/composables/useVolumeThumbnailing.ts
@@ -63,13 +63,15 @@ export function useVolumeThumbnailing(
 
   // used to interrupt a thumbnailing cycle if
   // doThumbnailing is called again
+  const UNMOUNTED = Symbol('unmount');
   let interruptSentinel = Symbol('interrupt');
 
-  // captureImages() finishes its render on a timer, so the render window has to
-  // outlive every in-flight capture; this chain tracks them for unmount
-  let activeThumbnailing = Promise.resolve();
+  // captures finish on a timer, so deletion waits for the in-flight ones
+  const inFlightCaptures = new Set<Promise<string>>();
 
   async function doThumbnailing(imageID: string, image: vtkImageData) {
+    if (interruptSentinel === UNMOUNTED) return;
+
     const localSentinel = Symbol('interrupt');
     interruptSentinel = localSentinel;
 
@@ -116,17 +118,24 @@ export function useVolumeThumbnailing(
 
       const renWin = thumbnailer.scene.getRenderWindow();
       renWin.render();
-      const imageURL = await renWin.captureImages()[0];
+      const capture = renWin.captureImages()[0];
+      inFlightCaptures.add(capture);
+      const imageURL = await capture.finally(() => {
+        inFlightCaptures.delete(capture);
+      });
+
+      // the capture spans a render, so the cycle may have been superseded
+      if (interruptSentinel !== localSentinel) return;
+      if (imageID !== currentImageID.value) return;
+
       if (imageURL) {
         thumbnails[imageID][presetName] = imageURL;
       }
     }
 
-    // chaining off the previous cycle keeps a capture it still has in flight
-    // covered by the tracking promise; its presets bail out through the sentinel
-    activeThumbnailing = PresetNameList.reduce(
+    PresetNameList.reduce(
       (promise, presetName) => promise.then(() => helper(presetName)),
-      activeThumbnailing
+      Promise.resolve()
     ).catch(logError);
   }
 
@@ -144,8 +153,10 @@ export function useVolumeThumbnailing(
 
   // force thumbnailing to stop
   onBeforeUnmount(() => {
-    interruptSentinel = Symbol('unmount');
-    activeThumbnailing.finally(() => thumbnailer.delete()).catch(logError);
+    interruptSentinel = UNMOUNTED;
+    Promise.allSettled([...inFlightCaptures])
+      .then(() => thumbnailer.delete())
+      .catch(logError);
   });
 
   // trigger thumbnailing

--- a/src/core/thumbnailers/volume-thumbnailer.ts
+++ b/src/core/thumbnailers/volume-thumbnailer.ts
@@ -9,7 +9,10 @@ import vtkLookupTableProxy from '@kitware/vtk.js/Proxy/Core/LookupTableProxy';
 import { vec3 } from 'gl-matrix';
 import type { Vector3 } from '@kitware/vtk.js/types';
 import vtkVolumeProperty from '@kitware/vtk.js/Rendering/Core/VolumeProperty';
+import vtkOpenGLRenderWindow from '@kitware/vtk.js/Rendering/OpenGL/RenderWindow';
 import { getDiagonalLength } from '@kitware/vtk.js/Common/DataModel/BoundingBox';
+import { beginContextRelease } from '@/src/core/vtk/releaseRenderWindow';
+import { deleteInteractor } from '@/src/core/vtk/deleteInteractor';
 
 export function createRenderingPipeline() {
   const actor = vtkVolume.newInstance();
@@ -126,6 +129,33 @@ export function createVolumeThumbnailer(size: number) {
         // ensure correct lighting post camera manip
         renderer.updateLightsGeometryToFollowCamera();
       }
+    },
+    delete() {
+      renderer.removeVolume(actor);
+      // scene.delete() deletes the API specific render window, so the context
+      // can only be handed back afterwards
+      const apiRenderWindow =
+        scene.getApiSpecificRenderWindow() as vtkOpenGLRenderWindow;
+      const loseContext = beginContextRelease(apiRenderWindow);
+      const interactor = scene.getInteractor();
+      const renderWindow = scene.getRenderWindow();
+      try {
+        // nothing that walks the render window's view list should reach the
+        // deleted view
+        renderWindow.removeView(apiRenderWindow);
+        scene.delete();
+        deleteInteractor(interactor);
+      } finally {
+        loseContext();
+      }
+      renderWindow.delete();
+      renderer.delete();
+      actor.delete();
+      mapper.delete();
+      opacityFuncProxy.delete();
+      colorTransferFuncProxy.delete();
+      pipeline.cfun.delete();
+      pipeline.ofun.delete();
     },
   };
 }

--- a/src/core/vtk/__tests__/useVtkView.spec.ts
+++ b/src/core/vtk/__tests__/useVtkView.spec.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { defineComponent, effectScope, h, ref } from 'vue';
+import { mount } from '@vue/test-utils';
+import vtkRenderWindow from '@kitware/vtk.js/Rendering/Core/RenderWindow';
+import vtkRenderWindowInteractor from '@kitware/vtk.js/Rendering/Core/RenderWindowInteractor';
+import vtkOpenGLRenderWindow from '@kitware/vtk.js/Rendering/OpenGL/RenderWindow';
+import { VtkRenderWindowParentContext } from '@/src/components/vtk/context';
+import { VtkRenderWindowParentApi } from '@/src/types/vtk-types';
+import { useVtkView, useWebGLRenderWindow } from '@/src/core/vtk/useVtkView';
+
+function createParent() {
+  const renderWindow = vtkRenderWindow.newInstance();
+  const renderWindowView = renderWindow.newAPISpecificView(
+    'WebGL'
+  ) as vtkOpenGLRenderWindow;
+  renderWindow.addView(renderWindowView);
+  return { renderWindow, renderWindowView };
+}
+
+function createRecordingParent(calls: Array<string>) {
+  const { renderWindow, renderWindowView } = createParent();
+  // an uninitialized interactor keeps the parent's renders inert: the test DOM
+  // has no WebGL context to traverse
+  renderWindow.setInteractor(vtkRenderWindowInteractor.newInstance());
+
+  return {
+    renderWindow: {
+      ...renderWindow,
+      removeRenderWindow: (child: vtkRenderWindow) => {
+        calls.push('removeRenderWindow');
+        return renderWindow.removeRenderWindow(child);
+      },
+    },
+    renderWindowView: {
+      ...renderWindowView,
+      removeNode: (node: vtkOpenGLRenderWindow) => {
+        calls.push('removeNode');
+        return renderWindowView.removeNode(node);
+      },
+    },
+  } as unknown as VtkRenderWindowParentApi;
+}
+
+function mountViewUnder(parent: VtkRenderWindowParentApi) {
+  const component = defineComponent({
+    setup() {
+      // no container: attaching one kicks off renders the test DOM cannot
+      // service without a WebGL context
+      useVtkView(ref(null));
+      return () => h('div');
+    },
+  });
+  return mount(component, {
+    global: {
+      provide: { [VtkRenderWindowParentContext as symbol]: parent },
+    },
+  });
+}
+
+describe('useVtkView teardown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('queues no render work once the view scope is disposed', () => {
+    const container = document.createElement('div');
+    const scope = effectScope(true);
+    const view = scope.run(() => useVtkView(container))!;
+
+    scope.stop();
+
+    view.requestRender();
+    view.requestRender({ immediate: true });
+
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('takes its view node off the parent scene graph on dispose', () => {
+    const parent = createParent();
+    const renderWindow = vtkRenderWindow.newInstance();
+    const container = document.createElement('div');
+    const scope = effectScope(true);
+
+    const renderWindowView = scope.run(() =>
+      useWebGLRenderWindow(renderWindow, container, parent)
+    )!;
+    expect(parent.renderWindowView.getChildren()).toHaveLength(1);
+
+    scope.stop();
+
+    expect(parent.renderWindowView.getChildren()).toHaveLength(0);
+    expect(renderWindowView.isDeleted()).toBe(true);
+  });
+
+  it('unregisters from the parent render window before dropping its view node', () => {
+    const calls: Array<string> = [];
+    const wrapper = mountViewUnder(createRecordingParent(calls));
+
+    wrapper.unmount();
+
+    expect(calls).toEqual(['removeRenderWindow', 'removeNode']);
+  });
+});

--- a/src/core/vtk/__tests__/useVtkView.spec.ts
+++ b/src/core/vtk/__tests__/useVtkView.spec.ts
@@ -4,8 +4,10 @@ import { mount } from '@vue/test-utils';
 import vtkRenderWindow from '@kitware/vtk.js/Rendering/Core/RenderWindow';
 import vtkRenderWindowInteractor from '@kitware/vtk.js/Rendering/Core/RenderWindowInteractor';
 import vtkOpenGLRenderWindow from '@kitware/vtk.js/Rendering/OpenGL/RenderWindow';
+import vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
 import { VtkRenderWindowParentContext } from '@/src/components/vtk/context';
 import { VtkRenderWindowParentApi } from '@/src/types/vtk-types';
+import { releaseWidgetManager } from '@/src/core/vtk/releaseWidgetManager';
 import { useVtkView, useWebGLRenderWindow } from '@/src/core/vtk/useVtkView';
 
 function createParent() {
@@ -103,5 +105,52 @@ describe('useVtkView teardown', () => {
     wrapper.unmount();
 
     expect(calls).toEqual(['removeRenderWindow', 'removeNode']);
+  });
+
+  function createSelectorStubs(released: Array<string>) {
+    const depthTexture = {} as WebGLRenderbuffer;
+    const context = {
+      deleteRenderbuffer: (renderbuffer: WebGLRenderbuffer) => {
+        released.push(
+          renderbuffer === depthTexture ? 'depthRenderbuffer' : 'unexpected'
+        );
+      },
+    } as unknown as WebGLRenderingContext;
+    const framebuffer = {
+      isDeleted: () => false,
+      releaseGraphicsResources: () => {
+        released.push('framebuffer');
+      },
+      getColorTexture: () => ({
+        releaseGraphicsResources: () => {
+          released.push('colorTexture');
+        },
+      }),
+      get: () => ({ context, depthTexture }),
+    };
+    return {
+      get: () => ({
+        _selector: { isDeleted: () => false, get: () => ({ framebuffer }) },
+      }),
+      delete: () => {
+        released.push('managerDeleted');
+      },
+    } as unknown as vtkWidgetManager;
+  }
+
+  it('hands back the selector framebuffer, color texture and depth renderbuffer', () => {
+    const released: Array<string> = [];
+    const rootView = {
+      isDeleted: () => false,
+    } as unknown as vtkOpenGLRenderWindow;
+
+    releaseWidgetManager(createSelectorStubs(released), rootView);
+
+    expect(released).toEqual([
+      'colorTexture',
+      'depthRenderbuffer',
+      'framebuffer',
+      'managerDeleted',
+    ]);
   });
 });

--- a/src/core/vtk/__tests__/useVtkView.spec.ts
+++ b/src/core/vtk/__tests__/useVtkView.spec.ts
@@ -153,4 +153,15 @@ describe('useVtkView teardown', () => {
       'managerDeleted',
     ]);
   });
+
+  it('still deletes the manager when the root view is already gone', () => {
+    const released: Array<string> = [];
+    const rootView = {
+      isDeleted: () => true,
+    } as unknown as vtkOpenGLRenderWindow;
+
+    releaseWidgetManager(createSelectorStubs(released), rootView);
+
+    expect(released).toEqual(['managerDeleted']);
+  });
 });

--- a/src/core/vtk/deleteInteractor.ts
+++ b/src/core/vtk/deleteInteractor.ts
@@ -1,0 +1,21 @@
+import type vtkRenderWindowInteractor from '@kitware/vtk.js/Rendering/Core/RenderWindowInteractor';
+
+// vtk.js' public cancelAnimation() is a no-op while the post-wheel extension
+// window is still open (model._animationExtendedEnd), so a pending rAF can
+// survive dispose and fire against a deleted interactor.
+function cancelPendingAnimationFrame(interactor: vtkRenderWindowInteractor) {
+  const model = (
+    interactor as unknown as { get(): { animationRequest?: number | null } }
+  ).get();
+  if (model.animationRequest == null) return;
+
+  cancelAnimationFrame(model.animationRequest);
+  model.animationRequest = null;
+}
+
+// interactor.delete() cancels outstanding animations by rendering, through a
+// view its callers have already deleted, so the pending frame has to go first.
+export function deleteInteractor(interactor: vtkRenderWindowInteractor) {
+  cancelPendingAnimationFrame(interactor);
+  interactor.delete();
+}

--- a/src/core/vtk/releaseRenderWindow.ts
+++ b/src/core/vtk/releaseRenderWindow.ts
@@ -1,0 +1,55 @@
+import type vtkOpenGLRenderWindow from '@kitware/vtk.js/Rendering/OpenGL/RenderWindow';
+import { NOOP } from '@/src/constants';
+import { Maybe } from '@/src/types';
+
+export type WebGLContext = WebGLRenderingContext | WebGL2RenderingContext;
+
+// releaseGraphicsResources is not in vtk.js' typings for vtkOpenGLRenderWindow,
+// and neither is the shape of its model.
+type ReleasableRenderWindow = vtkOpenGLRenderWindow & {
+  releaseGraphicsResources(): void;
+};
+
+type RenderWindowModel = {
+  get(): {
+    context?: Maybe<WebGLContext>;
+    rootOpenGLRenderWindow?: Maybe<vtkOpenGLRenderWindow>;
+  };
+};
+
+/**
+ * Releases a WebGL render window along with the browser context behind it.
+ *
+ * delete() alone leaves the context live until the canvas is collected, and
+ * browsers force-lose the oldest context past their per page cap. loseContext()
+ * runs after delete() because delete() removes the webglcontextlost handler
+ * that would ask the browser to restore what we are giving up.
+ */
+export function releaseOpenGLRenderWindow(view: vtkOpenGLRenderWindow) {
+  if (view.isDeleted()) return;
+  const loseContext = beginContextRelease(view);
+  try {
+    view.delete();
+  } finally {
+    loseContext();
+  }
+}
+
+/**
+ * Frees a render window's GPU resources and returns the step that gives the
+ * browser context back, for owners whose own teardown chain deletes the view
+ * for them.
+ *
+ * Only a root render window holds a context; a child proxies getContext() and
+ * releaseGraphicsResources() to the root, so releasing through one would take
+ * out the resources its siblings are still drawing with.
+ */
+export function beginContextRelease(view: vtkOpenGLRenderWindow) {
+  const releasable = view as ReleasableRenderWindow;
+  const model = (view as unknown as RenderWindowModel).get();
+  if (model.rootOpenGLRenderWindow) return NOOP;
+
+  const context = model.context;
+  if (context) releasable.releaseGraphicsResources();
+  return () => context?.getExtension('WEBGL_lose_context')?.loseContext();
+}

--- a/src/core/vtk/releaseWidgetManager.ts
+++ b/src/core/vtk/releaseWidgetManager.ts
@@ -1,0 +1,45 @@
+import type vtkOpenGLRenderWindow from '@kitware/vtk.js/Rendering/OpenGL/RenderWindow';
+import type vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
+import { Maybe } from '@/src/types';
+
+type SelectorFramebuffer = {
+  isDeleted(): boolean;
+  releaseGraphicsResources(): void;
+  getColorTexture(): Maybe<{
+    releaseGraphicsResources(view: vtkOpenGLRenderWindow): void;
+  }>;
+};
+
+type HardwareSelector = {
+  isDeleted(): boolean;
+  get(): { framebuffer?: Maybe<SelectorFramebuffer> };
+};
+
+/**
+ * Deletes a widget manager and frees the picking resources vtk.js leaves behind.
+ *
+ * vtkWidgetManager.delete() drops only its own subscriptions, so the hardware
+ * selector's framebuffer and color texture pile up on the shared context one
+ * set per view.
+ *
+ * rootView owns that context, so there is nothing to hand back once it is gone.
+ */
+export function releaseWidgetManager(
+  manager: vtkWidgetManager,
+  rootView: vtkOpenGLRenderWindow
+) {
+  const selector = (
+    manager as unknown as { get(): { _selector?: Maybe<HardwareSelector> } }
+  ).get()._selector;
+  const framebuffer =
+    selector && !selector.isDeleted() ? selector.get().framebuffer : null;
+
+  try {
+    if (framebuffer && !framebuffer.isDeleted() && !rootView.isDeleted()) {
+      framebuffer.getColorTexture()?.releaseGraphicsResources(rootView);
+      framebuffer.releaseGraphicsResources();
+    }
+  } finally {
+    manager.delete();
+  }
+}

--- a/src/core/vtk/releaseWidgetManager.ts
+++ b/src/core/vtk/releaseWidgetManager.ts
@@ -1,5 +1,6 @@
 import type vtkOpenGLRenderWindow from '@kitware/vtk.js/Rendering/OpenGL/RenderWindow';
 import type vtkWidgetManager from '@kitware/vtk.js/Widgets/Core/WidgetManager';
+import { WebGLContext } from '@/src/core/vtk/releaseRenderWindow';
 import { Maybe } from '@/src/types';
 
 type SelectorFramebuffer = {
@@ -8,6 +9,10 @@ type SelectorFramebuffer = {
   getColorTexture(): Maybe<{
     releaseGraphicsResources(view: vtkOpenGLRenderWindow): void;
   }>;
+  get(): {
+    context?: Maybe<WebGLContext>;
+    depthTexture?: Maybe<WebGLRenderbuffer>;
+  };
 };
 
 type HardwareSelector = {
@@ -19,8 +24,9 @@ type HardwareSelector = {
  * Deletes a widget manager and frees the picking resources vtk.js leaves behind.
  *
  * vtkWidgetManager.delete() drops only its own subscriptions, so the hardware
- * selector's framebuffer and color texture pile up on the shared context one
- * set per view.
+ * selector's framebuffer, color texture and depth renderbuffer pile up on the
+ * shared context one set per view; the framebuffer's releaseGraphicsResources()
+ * covers itself alone, hence the explicit renderbuffer handback.
  *
  * rootView owns that context, so there is nothing to hand back once it is gone.
  */
@@ -37,6 +43,10 @@ export function releaseWidgetManager(
   try {
     if (framebuffer && !framebuffer.isDeleted() && !rootView.isDeleted()) {
       framebuffer.getColorTexture()?.releaseGraphicsResources(rootView);
+      const { context, depthTexture } = framebuffer.get();
+      if (context && depthTexture) {
+        context.deleteRenderbuffer(depthTexture);
+      }
       framebuffer.releaseGraphicsResources();
     }
   } finally {

--- a/src/core/vtk/useVtkView.ts
+++ b/src/core/vtk/useVtkView.ts
@@ -3,6 +3,9 @@ import { onVTKEvent } from '@/src/composables/onVTKEvent';
 import { View } from '@/src/core/vtk/types';
 import { Maybe } from '@/src/types';
 import { VtkRenderWindowParentApi } from '@/src/types/vtk-types';
+import { releaseOpenGLRenderWindow } from '@/src/core/vtk/releaseRenderWindow';
+import { releaseWidgetManager } from '@/src/core/vtk/releaseWidgetManager';
+import { deleteInteractor } from '@/src/core/vtk/deleteInteractor';
 import { batchForNextTask } from '@/src/utils/batchForNextTask';
 import vtkRenderWindow from '@kitware/vtk.js/Rendering/Core/RenderWindow';
 import vtkRenderWindowInteractor from '@kitware/vtk.js/Rendering/Core/RenderWindowInteractor';
@@ -18,23 +21,6 @@ import {
   watchEffect,
   watchPostEffect,
 } from 'vue';
-
-// vtk.js' public interactor.cancelAnimation() is a no-op while the
-// post-wheel extension window is still open (model._animationExtendedEnd),
-// so on dispose during that window a pending rAF survives and fires against
-// the deleted interactor. Reach into the private animationRequest field to
-// cancel it directly.
-function cancelPendingInteractorAnimationFrame(
-  interactor: vtkRenderWindowInteractor
-) {
-  const model = (
-    interactor as unknown as { get(): { animationRequest?: number | null } }
-  ).get();
-  if (model.animationRequest == null) return;
-
-  cancelAnimationFrame(model.animationRequest);
-  model.animationRequest = null;
-}
 
 export function useWebGLRenderWindow(
   renderWindow: vtkRenderWindow,
@@ -57,10 +43,12 @@ export function useWebGLRenderWindow(
   });
 
   onScopeDispose(() => {
+    // a child node draws through its parent's context, so only the standalone
+    // case has one of its own to release
     if (parent?.renderWindowView) {
       parent.renderWindowView.removeNode(renderWindowView);
     } else {
-      renderWindowView.delete();
+      releaseOpenGLRenderWindow(renderWindowView);
     }
   });
 
@@ -98,6 +86,15 @@ export function useVtkView(container: MaybeRef<Maybe<HTMLElement>>): View {
   const renderer = vtkRenderer.newInstance();
   const renderWindow = vtkRenderWindow.newInstance();
   renderWindow.addRenderer(renderer);
+
+  let disposed = false;
+
+  // the parent rebuilds its scene graph from its own child render window list,
+  // so a child comes off that list before its view node goes
+  onScopeDispose(() => {
+    disposed = true;
+    parent?.renderWindow.removeRenderWindow(renderWindow);
+  });
 
   parent?.renderWindow.addRenderWindow(renderWindow);
 
@@ -141,7 +138,10 @@ export function useVtkView(container: MaybeRef<Maybe<HTMLElement>>): View {
     renderWindow.render();
   };
 
+  // requests outlive the view: vtk event handlers and promises that settle
+  // after dispose has deleted the scene graph nodes a render would traverse
   const requestRender = ({ immediate } = { immediate: false }) => {
+    if (disposed) return;
     if (immediate) {
       immediateRender();
     }
@@ -172,16 +172,20 @@ export function useVtkView(container: MaybeRef<Maybe<HTMLElement>>): View {
   });
 
   // cleanup
+  const rootRenderWindowView = parent?.renderWindowView ?? renderWindowView;
+
   onScopeDispose(() => {
     deferredRender.cancel();
 
-    renderWindow.removeRenderer(renderer);
-    parent?.renderWindow.removeRenderWindow(renderWindow);
+    try {
+      releaseWidgetManager(widgetManager, rootRenderWindowView);
+    } finally {
+      renderWindow.removeRenderer(renderer);
 
-    renderer.delete();
-    renderWindow.delete();
-    cancelPendingInteractorAnimationFrame(interactor);
-    interactor.delete();
+      renderer.delete();
+      renderWindow.delete();
+      deleteInteractor(interactor);
+    }
   });
 
   return {

--- a/src/core/vtk/useVtkView.ts
+++ b/src/core/vtk/useVtkView.ts
@@ -6,6 +6,7 @@ import { VtkRenderWindowParentApi } from '@/src/types/vtk-types';
 import { releaseOpenGLRenderWindow } from '@/src/core/vtk/releaseRenderWindow';
 import { releaseWidgetManager } from '@/src/core/vtk/releaseWidgetManager';
 import { deleteInteractor } from '@/src/core/vtk/deleteInteractor';
+import { NOOP } from '@/src/constants';
 import { batchForNextTask } from '@/src/utils/batchForNextTask';
 import vtkRenderWindow from '@kitware/vtk.js/Rendering/Core/RenderWindow';
 import vtkRenderWindowInteractor from '@kitware/vtk.js/Rendering/Core/RenderWindowInteractor';
@@ -88,11 +89,14 @@ export function useVtkView(container: MaybeRef<Maybe<HTMLElement>>): View {
   renderWindow.addRenderer(renderer);
 
   let disposed = false;
+  let releaseWidgets = NOOP;
 
-  // the parent rebuilds its scene graph from its own child render window list,
-  // so a child comes off that list before its view node goes
+  // registered first so it runs before the teardown below: picking resources go
+  // back through the root view, and the parent rebuilds its scene graph from
+  // its own child render window list
   onScopeDispose(() => {
     disposed = true;
+    releaseWidgets();
     parent?.renderWindow.removeRenderWindow(renderWindow);
   });
 
@@ -123,6 +127,11 @@ export function useVtkView(container: MaybeRef<Maybe<HTMLElement>>): View {
 
   // widget manager
   const widgetManager = useWidgetManager(renderer);
+  releaseWidgets = () =>
+    releaseWidgetManager(
+      widgetManager,
+      parent?.renderWindowView ?? renderWindowView
+    );
 
   // render API
   const deferredRender = batchForNextTask(() => {
@@ -172,20 +181,14 @@ export function useVtkView(container: MaybeRef<Maybe<HTMLElement>>): View {
   });
 
   // cleanup
-  const rootRenderWindowView = parent?.renderWindowView ?? renderWindowView;
-
   onScopeDispose(() => {
     deferredRender.cancel();
 
-    try {
-      releaseWidgetManager(widgetManager, rootRenderWindowView);
-    } finally {
-      renderWindow.removeRenderer(renderer);
+    renderWindow.removeRenderer(renderer);
 
-      renderer.delete();
-      renderWindow.delete();
-      deleteInteractor(interactor);
-    }
+    renderer.delete();
+    renderWindow.delete();
+    deleteInteractor(interactor);
   });
 
   return {


### PR DESCRIPTION
## Problem

**Contexts are never handed back.** Deleting a `vtkOpenGLRenderWindow` only
decrements vtk.js' own counter. The browser keeps the WebGL context alive until
the canvas is collected, and browsers cap how many contexts a page may hold, so
past the cap the oldest is force lost and new ones fail. The volume thumbnailer
makes this reachable in normal use: it owns a render window of its own, and the
rendering panel that creates it sits behind `v-if="canShow3DControls"`, so every
layout change that adds or removes a 3D view rebuilds it. There was no disposal
path at all.

Attribution, since it is easy to get backwards: the layout-change context
exhaustion is fixed entirely by the thumbnailer work. Regular views do not leak
a context per layout change, because a child view draws through its parent's and
the only owner is `VtkRenderWindowParent`, whose disposal runs at app teardown.
The rest of this PR is hardening.

**Render requests outlive the view.** `requestRender` and the `batchForNextTask`
render are reachable from vtk event handlers and from promises that settle after
the view is gone, so a request can arrive after `onScopeDispose` and leave a
timer queued behind a view that is going away. On `main` such a render did not
reach the mappers: `interactor.delete()` empties the interactor model, which
makes `isAnimating()` return true, and that check is the first statement of both
render paths. The observable defect is the stray timer.

**The widget manager was never deleted, and its picking buffers still are not
freed by vtk.js.** `useWidgetManager` registered no disposal, so
`vtkWidgetManager.delete()` never ran and its interactor, camera and resize
subscriptions stayed live. `delete()` is also all it does: it never touches the
hardware selector. `vtkOpenGLHardwareSelector` allocates a framebuffer, a color
texture, and a depth renderbuffer on the shared context the first time picking
captures, has no `delete()` override, and nothing in vtk.js 36.2.1 releases
them, so one set per view accumulated across layout changes.

## Change

Six commits.

**`fix(vtk): stop renders and release resources when a view is torn down`**

- `requestRender` short circuits once the scope is disposed.
- A child render window is unregistered from its parent before its view node is
  removed.
- The view's widget manager is torn down on scope dispose. New
  `releaseWidgetManager.ts` releases the hardware selector's framebuffer and
  color texture against the root render window, then `manager.delete()` drops
  its subscriptions. Both steps are guarded, so a manager that never captured is
  a no-op and the release cannot skip the renderer, render window and interactor
  cleanup that follows.
- New `releaseRenderWindow.ts` releases GPU resources and hands the browser
  context back via `WEBGL_lose_context`. `beginContextRelease` returns the lose
  step separately, for owners whose teardown chain deletes the view for them,
  and runs it from a `finally` so a throw in between cannot strand the context.
  It acts only on a root render window: vtk.js proxies `getContext` and
  `releaseGraphicsResources` from a child to its root, so a child handed to it
  would free what its siblings are still drawing with.
- New `deleteInteractor.ts` owns the drop-the-pending-frame-then-delete pair.
  `interactor.delete()` cancels outstanding animations, and each cancellation
  renders through a view its callers have already deleted; vtk.js' public
  `cancelAnimation()` is a no-op inside the post-wheel extension window, so the
  pending rAF is dropped directly. It replaces the copy `useVtkView` kept
  inline, and picks up a second caller in the next commit.

**`fix(rendering): release the volume thumbnailer's WebGL context on unmount`**

- `createVolumeThumbnailer` gains `delete()`, called from
  `useVolumeThumbnailing`'s `onBeforeUnmount` and guarded so a failure cannot
  abort the rest of the unmount. Teardown errors go through `logError`, which
  walks `error.cause` chains, so the underlying WebGL error is not hidden behind
  the outer message.
- Ordering matters: `vtkGenericRenderWindow.delete()` runs `setContainer`, which
  unbinds interactor events and deletes the API specific render window, so both
  must still be alive when it runs. Resources are released first, then
  `scene.delete()`, then the interactor, then the context from a `finally`.
- The API specific view comes off the inner `vtkRenderWindow` before
  `scene.delete()`, so a scheduled render walks an empty list instead of a
  deleted node.
- The interactor goes through `deleteInteractor`, so its pending animation frame
  is dropped rather than rendered through the view `scene.delete()` just took
  apart.
- `releaseOpenGLRenderWindow` returns early when the view is already deleted, so
  a second call cannot throw.
- The rest of the pipeline goes with it: inner render window, renderer, actor,
  mapper, the two function proxies, and the colour and opacity functions.

**`fix(rendering): defer thumbnailer deletion until captures settle`**

`captureImages()` finishes its render on a zero-delay timer, so deleting the
render window while a capture is pending crashed that callback and left the
capture promise unresolved. Unmount now waits for in-flight captures before
deleting; the remaining presets bail out through the existing interrupt
sentinel. The tracking mechanism was reworked by a later commit, below.

**`fix(vtk): release the selector framebuffer's depth renderbuffer`**

`Framebuffer.releaseGraphicsResources()` deletes the framebuffer but not the
depth renderbuffer `populateFramebuffer()` created, so one renderbuffer leaked
per disposed view on the shared context.

**`fix(rendering): track in-flight captures instead of chaining cycles`**

The first version of the deferral chained every thumbnailing cycle onto the
previous cycle's promise, so a single capture that never settles (lost context,
render that emits no image) would have wedged all future thumbnailing and kept
the deferred `delete()` from ever running, making the context leak permanent.

- In-flight captures are tracked in a set; unmount awaits `Promise.allSettled`
  of just those, and each cycle's preset chain starts fresh.
- A cycle that starts between `onBeforeUnmount` and scope stop bails on the
  unmount sentinel instead of overwriting it and rendering through a deleted
  scene.
- The sentinel and current image id are re-checked after the capture resolves,
  so a capture that renders the newly selected image is dropped instead of
  stored under the previous image's id.

**`fix(vtk): release widget manager before its root view is deleted`**

- In the standalone (no parent) path, the dispose hook that deletes the view
  registered earlier than the final cleanup, so `releaseWidgetManager` always
  saw `rootView.isDeleted()` and the selector framebuffer release was dead
  code there. The widget manager release now registers ahead of the view
  teardown; the child-path ordering (unregister from the parent render window,
  then drop the view node) is unchanged and still covered by the spec.
- The select tool's pick handler awaits `getSelectedDataForXY`, which a view
  teardown can outrun now that the widget manager is actually deleted, so the
  pick re-checks `isDeleted()` after the await.

## Known gaps

- **Per-view polydata VBO retention** is not addressed. The OpenGL image and
  volume mappers chain `unregisterGraphicsResourceUser` into `delete()`, so
  their textures on the shared context are freed when a child view closes, but
  `vtkOpenGLPolyDataMapper` has no `delete()` override and no public release
  path, and a child view's `releaseGraphicsResources` proxies to the root,
  which would free what sibling views still draw with. Pre-existing, and needs
  a vtk.js-side fix rather than teardown ordering.
- **Deferred deletion is not bounded by a deadline.** Unmount waits on the
  in-flight capture set with no timeout, so a capture that never settles would
  hold the thumbnailer, and its context, indefinitely. Releasing eagerly would
  break exactly those captures, so the wait stands; bounding it wants
  `delete()` to be safe with a capture pending rather than a timer.
- **Deferred deletion briefly overlaps contexts on remount.** A remount creates
  its thumbnailer context synchronously while the old one waits for in-flight
  captures to settle. Releasing eagerly would break exactly those captures, so
  the overlap is accepted; it is now bounded by the in-flight set rather than
  an unbounded chain.
- **The context cap symptom is not reproducible in our e2e environment.** Those
  runs are headless with `--enable-unsafe-swiftshader`, and software rendering
  does not enforce the live context limit that causes the failure on real GPUs.
  A spec that cycled the layout twenty times passed against unfixed code, so it
  was not kept. The release paths were verified against the vtk.js 36.2.1
  sources instead.
